### PR TITLE
Fix arg parsing in libbpf plugin

### DIFF
--- a/libbpf_plugin/libbpf_plugin.cc
+++ b/libbpf_plugin/libbpf_plugin.cc
@@ -94,12 +94,27 @@ int
 main(int argc, char** argv)
 {
     bool debug = false;
-    std::vector<std::string> args(argv + 1, argv + argc - 1);
+    std::vector<std::string> args(argv, argv + argc);
+    if (argc.size() > 0) {
+        args.erase(args.begin());
+    }
     std::string program_string;
     std::string memory_string;
-    std::getline(std::cin, program_string);
 
-    // First parameter is optional memory contents.
+    if (args.size() > 0 && args[0] == "--help") {
+        std::cout << "usage: " << argv[0] << " [--program <base16 program bytes>] [<base16 memory bytes>] [--debug]" << std::endl;
+        return 1;
+    }
+
+    if (args.size() > 1 && args[0] == "--program") {
+        args.erase(args.begin());
+        program_string = args[0];
+        args.erase(args.begin());
+    } else {
+        std::getline(std::cin, program_string);
+    }
+
+    // Next parameter is optional memory contents.
     if (args.size() > 0 && args[0] != "--debug") {
         memory_string = args[0];
         args.erase(args.begin());

--- a/libbpf_plugin/libbpf_plugin.cc
+++ b/libbpf_plugin/libbpf_plugin.cc
@@ -95,7 +95,7 @@ main(int argc, char** argv)
 {
     bool debug = false;
     std::vector<std::string> args(argv, argv + argc);
-    if (argc.size() > 0) {
+    if (args.size() > 0) {
         args.erase(args.begin());
     }
     std::string program_string;

--- a/libbpf_plugin/libbpf_plugin.cc
+++ b/libbpf_plugin/libbpf_plugin.cc
@@ -123,7 +123,7 @@ main(int argc, char** argv)
         debug = true;
         args.erase(args.begin());
     }
-    if (args.size() > 0) {
+    if (args.size() > 0 && args[0].size() > 0) {
         std::cerr << "Unexpected arguments: " << args[0] << std::endl;
         return 1;
     }


### PR DESCRIPTION
Also provide an option to accept the program string as a command line arg

Signed-off-by: Dave Thaler <dthaler@microsoft.com>