### PR TITLE
Fix macOS build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,11 +5,8 @@ set(CMAKE_CXX_STANDARD 20)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
     "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  find_package(Boost REQUIRED)
-  find_package(Boost_program_options REQUIRED)
-  find_package(boost_filesystem REQUIRED)
-  set(CMAKE_CXX_STANDARD 20)
-  set(PLATFORM_LIB pthread boost_program_options boost_filesystem)
+  find_package(Boost REQUIRED COMPONENTS program_options filesystem)
+  set(PLATFORM_LIB pthread "${Boost_LIBRARIES}")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   find_program(NUGET nuget)
   if ("${BOOST_VERSION}" STREQUAL "")

--- a/src/runner.cc
+++ b/src/runner.cc
@@ -101,6 +101,9 @@ main(int argc, char** argv)
             case bpf_conformance_test_result_t::TEST_RESULT_SKIP:
                 std::cout << "SKIP: " << test.first << " " << message << std::endl;
                 break;
+            case bpf_conformance_test_result_t::TEST_RESULT_UNKNOWN:
+                std::cout << "UNKNOWN: " << test.first << " " << message << std::endl;
+                break;
             }
         }
 


### PR DESCRIPTION
This fixes the build on macOS in two steps:

1. Ensures we output text for all types of results (removes some warnings).
2. Changes how we attempt to find Boost using CMake.

Tested on my local M1 Macbook Pro, and Arm64 Linux.