### PR TITLE
Add sign extending tests

### DIFF
--- a/tests/div64-negative-imm.data
+++ b/tests/div64-negative-imm.data
@@ -1,0 +1,8 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+-- asm
+lddw r0, 0xFFFFFFFFFFFFFFFF
+div r0, -10
+exit
+-- result
+0x1

--- a/tests/div64-negative-reg.data
+++ b/tests/div64-negative-reg.data
@@ -1,0 +1,9 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+-- asm
+lddw r0, 0xFFFFFFFFFFFFFFFF
+mov32 r1, -10
+div r0, r1
+exit
+-- result
+0x10000000A

--- a/tests/mov64-sign-extend.data
+++ b/tests/mov64-sign-extend.data
@@ -1,0 +1,7 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+-- asm
+mov r0, -10
+exit
+-- result
+0xFFFFFFFFFFFFFFF6


### PR DESCRIPTION
Add tests to verify sign extend behavior for mov64 and div64.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>