### PR TITLE
Add more test coverage

### DIFF
--- a/negative/invalid_lock2.data
+++ b/negative/invalid_lock2.data
@@ -1,0 +1,7 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+-- asm
+lock
+exit
+-- error
+Invalid number of operands for lock

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -252,6 +252,19 @@ set_tests_properties(
 )
 
 add_test(
+  NAME invalid_lock2
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_lock2.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug"
+  )
+
+set_tests_properties(
+  invalid_lock2
+  PROPERTIES
+  WILL_FAIL true
+  FAIL_REGULAR_EXPRESSION "Invalid number of operands for lock"
+)
+
+
+add_test(
   NAME include_test
   COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/tests/lock_add.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug" --include_regex lock
 )
@@ -310,7 +323,7 @@ set_tests_properties(
   missing_test_path
   PROPERTIES
   WILL_PASS true
-  PASS_REGULAR_EXPRESSION "test_file_path or test_file_directory is required"
+  PASS_REGULAR_EXPRESSION "test_file_path or test_file_directory"
 )
 
 add_test(
@@ -371,4 +384,26 @@ set_tests_properties(
   PROPERTIES
   WILL_FAIL true
   FAIL_REGULAR_EXPRESSION "Test file has no BPF instructions."
+)
+
+add_test(
+  NAME libbpf_program_bytes
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --program "b4  00  00  00  00  00  00  00 95  00  00  00  00  00  00  00"
+  )
+
+set_tests_properties(
+  libbpf_program_bytes
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION "0"
+)
+
+add_test(
+  NAME invalid_option
+  COMMAND ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --not_an_option 2>&1
+  )
+
+set_tests_properties(
+  invalid_option
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION "unrecognised option"
 )

--- a/tests/lock_cmpxchg.data
+++ b/tests/lock_cmpxchg.data
@@ -7,7 +7,7 @@ stxdw [r10-8], r0
 lddw r1, 0x1122334455667788
 lddw r0, 0xfedcba987654321
 # Expected to fail as [r10-8] != r1
-lock cmpxchg [r10-8], r1
+lock cmpxchg [r10-8], r1 # Atomically compare r0 and [r10-8] and set [r10-8] to r1 if matches.
 # Test if r0 contains value from [r10-8]
 lddw r1, 0x123456789abcdef0
 jne r0, r1, exit
@@ -19,7 +19,7 @@ lddw r0, 0x123456789abcdef0
 stxdw [r10-8], r0
 lddw r1, 0x1122334455667788
 # Expected to succeed
-lock cmpxchg [r10-8], r1
+lock cmpxchg [r10-8], r1 # Atomically compare r0 and [r10-8] and set [r10-8] to r1 if matches.
 # Test if r0 contains 0x123456789abcdef0
 lddw r1, 0x123456789abcdef0
 jne r0, r1, exit


### PR DESCRIPTION
Add missing coverage for lock parsing.
Add libbpf_plugin --program option.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>