### PR TITLE
Fix tests for 32-bit jumps (rsh -> lsh, mov -> mov32)

### DIFF
--- a/tests/jeq32-imm.data
+++ b/tests/jeq32-imm.data
@@ -3,7 +3,7 @@
 -- asm
 # Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0x0
 mov32 r1, 0xa
 jeq32 r1, 0xb, exit # Not taken

--- a/tests/jeq32-reg.data
+++ b/tests/jeq32-reg.data
@@ -3,7 +3,7 @@
 -- asm
 # Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
 mov32 r1, 0xa
 mov32 r2, 0xb

--- a/tests/jge32-imm.data
+++ b/tests/jge32-imm.data
@@ -1,8 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
 mov32 r1, 0xa
 jge32 r1, 0xb, exit # Not taken

--- a/tests/jge32-reg.data
+++ b/tests/jge32-reg.data
@@ -1,8 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
 mov32 r1, 0xa
 mov32 r2, 0xb

--- a/tests/jgt32-imm.data
+++ b/tests/jgt32-imm.data
@@ -1,8 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
 # set r1 to 0x100000005
 mov32 r1, 5

--- a/tests/jgt32-reg.data
+++ b/tests/jgt32-reg.data
@@ -1,8 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov r0, 0
 mov r1, 5
 mov32 r1, 5

--- a/tests/jle32-imm.data
+++ b/tests/jle32-imm.data
@@ -1,8 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
 mov32 r1, 5
 # set r1 to 0x100000005

--- a/tests/jle32-reg.data
+++ b/tests/jle32-reg.data
@@ -1,8 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov r0, 0
 mov r1, 5
 mov r2, 4

--- a/tests/jlt32-imm.data
+++ b/tests/jlt32-imm.data
@@ -1,8 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
 mov32 r1, 5
 # set r1 to 0x100000005

--- a/tests/jlt32-reg.data
+++ b/tests/jlt32-reg.data
@@ -1,8 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov r0, 0
 mov r1, 5
 mov r2, 4

--- a/tests/jne32-imm.data
+++ b/tests/jne32-imm.data
@@ -1,8 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
 mov32 r1, 0xb
 # set r1 to 0x10000000b

--- a/tests/jne32-reg.data
+++ b/tests/jne32-reg.data
@@ -1,8 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
 mov32 r1, 0xb
 # set r1 to 0x10000000b

--- a/tests/jset32-imm.data
+++ b/tests/jset32-imm.data
@@ -1,8 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
 mov32 r1, 0x7
 # set r1 to 0x100000007

--- a/tests/jset32-reg.data
+++ b/tests/jset32-reg.data
@@ -1,8 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
 mov32 r1, 0x7
 # set r1 to 0x100000007

--- a/tests/jsge32-imm.data
+++ b/tests/jsge32-imm.data
@@ -1,10 +1,11 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
-mov r1, 0xfffffffe
+mov32 r1, 0xfffffffe
 # set r1 to 0x1fffffffe
 or r1, r9
 jsge32 r1, 0xffffffff, exit # Not taken

--- a/tests/jsge32-reg.data
+++ b/tests/jsge32-reg.data
@@ -1,10 +1,11 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
-mov r1, 0xfffffffe
+mov32 r1, 0xfffffffe
 # set r1 to 0x1fffffffe
 or r1, r9
 mov r2, 0xffffffff

--- a/tests/jsgt32-imm.data
+++ b/tests/jsgt32-imm.data
@@ -1,10 +1,11 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
-mov r1, 0xfffffffe
+mov32 r1, 0xfffffffe
 # set r1 to 0x1fffffffe
 or r1, r9
 jsgt32 r1, 0xffffffff, exit # Not taken

--- a/tests/jsgt32-reg.data
+++ b/tests/jsgt32-reg.data
@@ -1,10 +1,11 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
-mov r1, 0xfffffffe
+mov32 r1, 0xfffffffe
 # set r1 to 0x1fffffffe
 or r1, r9
 mov r2, 0xffffffff

--- a/tests/jsle32-imm.data
+++ b/tests/jsle32-imm.data
@@ -1,10 +1,11 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
-mov r1, 0xfffffffe
+mov32 r1, 0xfffffffe
 # set r1 to 0x1fffffffe
 or r1, r9
 jsle32 r1, 0xfffffffd, exit # Not taken

--- a/tests/jsle32-reg.data
+++ b/tests/jsle32-reg.data
@@ -1,11 +1,12 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
-mov r1, 0xffffffff
-# set r1 to 0x1fffffffe
+mov32 r1, 0xffffffff
+# set r1 to 0x1ffffffff
 or r1, r9
 mov r2, 0xfffffffe
 mov32 r3, 0

--- a/tests/jslt32-imm.data
+++ b/tests/jslt32-imm.data
@@ -1,10 +1,11 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
-mov r1, 0xfffffffe
+mov32 r1, 0xfffffffe
 # set r1 to 0x1fffffffe
 or r1, r9
 jslt32 r1, 0xfffffffd, exit # Not taken

--- a/tests/jslt32-reg.data
+++ b/tests/jslt32-reg.data
@@ -1,10 +1,11 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
+# Set r9 to 0x100000000
 mov r9, 1
-rsh r9, 32
+lsh r9, 32
 mov32 r0, 0
-mov r1, 0xfffffffe
+mov32 r1, 0xfffffffe
 # set r1 to 0x1fffffffe
 or r1, r9
 mov r2, 0xfffffffd


### PR DESCRIPTION
There seems to be some mistakes in the tests related to 32-bit jumps:

- Setting `r9` to `0x100000000` would use a right shift, doing `1 >> 32`, but we want to shift left instead (`1 << 32`), or we would just set `r9` to `0`.

- Using a 64-bit move instruction to set `r1` with a negative value (usually `-2`, written as 32-bit operand `0xfffffffe`) is supposed to extend the sign to 64-bit, and does not set `r1` to `0xfffffffe` (but to `0xfffffffffffffffe` instead) as we desire for the test.

- In `tests/jsle32-reg.data`, the comment says we set `r1` to `-2`, when in fact we set it to `-1` (`0xffffffff`).

Use left shifts instead of right shifts, 32-bit moves where relevant in the tests for 32-bit jumps, and fix the comment in `jsle32-reg.data`.

Fixes: 2daa7363b1b3 ("Add support for EBPF_CLS_JMP32 (#29)")