### PR TITLE
Generate build artifacts daily

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -10,6 +10,9 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  # Run on a daily schedule to perform the full set of tests.
+  schedule:
+    - cron: '00 21 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
Build artifacts expire, so run daily to ensure there are always current versions.