### PR TITLE
Add option to display either used or unused instructions

### DIFF
--- a/include/bpf_conformance.h
+++ b/include/bpf_conformance.h
@@ -24,6 +24,14 @@ typedef enum class _bpf_conformance_test_CPU_version
     v3 = 3,
 } bpf_conformance_test_CPU_version_t;
 
+typedef enum class _bpf_conformance_list_instructions
+{
+    LIST_INSTRUCTIONS_NONE,   // Do not list instructions.
+    LIST_INSTRUCTIONS_USED,   // List instructions used by the test.
+    LIST_INSTRUCTIONS_UNUSED, // List instructions not used by the test.
+    LIST_INSTRUCTIONS_ALL,    // List all instructions.
+} bpf_conformance_list_instructions_t;
+
 /**
  * @brief Run the BPF conformance tests with the given plugin.
  *
@@ -45,5 +53,6 @@ bpf_conformance(
     std::optional<std::string> include_test_regex = std::nullopt,
     std::optional<std::string> exclude_test_regex = std::nullopt,
     bpf_conformance_test_CPU_version_t CPU_version = bpf_conformance_test_CPU_version_t::v3,
-    bool list_opcodes_tested = false,
+    bpf_conformance_list_instructions_t list_instructions_option =
+        bpf_conformance_list_instructions_t::LIST_INSTRUCTIONS_NONE,
     bool debug = false);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -384,3 +384,25 @@ set_tests_properties(
   PROPERTIES
   PASS_REGULAR_EXPRESSION "unrecognised option"
 )
+
+add_test(
+  NAME list_used_instructions
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${CMAKE_BINARY_DIR}/tests --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --cpu_version v1 --list_used_instructions true
+)
+
+set_tests_properties(
+  list_used_instructions
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION "Instructions used by tests"
+)
+
+add_test(
+  NAME list_unused_instructions
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${CMAKE_BINARY_DIR}/tests --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --cpu_version v1 --list_unused_instructions true
+)
+
+set_tests_properties(
+  list_unused_instructions
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION "Instructions not used by tests"
+)

--- a/src/bpf_conformance.cc
+++ b/src/bpf_conformance.cc
@@ -80,7 +80,7 @@ bpf_conformance(
     std::optional<std::string> include_test_regex,
     std::optional<std::string> exclude_test_regex,
     bpf_conformance_test_CPU_version_t CPU_version,
-    bool list_opcodes_tested,
+    bpf_conformance_list_instructions_t list_instructions_option,
     bool debug)
 {
     std::set<bpf_conformance_instruction_t, InstCmp> instructions_used;
@@ -275,23 +275,30 @@ bpf_conformance(
         log_debug_result(test_results, test);
     }
 
-    // If the caller asked for a list of opcodes used by the tests, then print the list.
-    if (list_opcodes_tested) {
-        // Compute list of opcodes not used in tests.
-        for (auto& instruction : instructions_from_spec) {
-            if (instructions_used.find(instruction) == instructions_used.end()) {
-                instructions_not_used.insert(instruction);
-            }
+    // Compute list of opcodes not used in tests.
+    for (auto& instruction : instructions_from_spec) {
+        if (instructions_used.find(instruction) == instructions_used.end()) {
+            instructions_not_used.insert(instruction);
         }
+    }
 
-        std::cout << "Instructions used:" << std::endl;
+    // If the caller asked for a list of opcodes used by the tests, then print the list.
+
+    if (list_instructions_option ==  bpf_conformance_list_instructions_t::LIST_INSTRUCTIONS_USED ||
+        list_instructions_option ==  bpf_conformance_list_instructions_t::LIST_INSTRUCTIONS_ALL) {
+        std::cout << "Instructions used by tests:" << std::endl;
         for (auto instruction : instructions_used) {
             std::cout << instruction_to_name(instruction) << std::endl;
         }
-        std::cout << "Instructions not used:" << std::endl;
+    }
+
+    if (list_instructions_option ==  bpf_conformance_list_instructions_t::LIST_INSTRUCTIONS_UNUSED ||
+        list_instructions_option ==  bpf_conformance_list_instructions_t::LIST_INSTRUCTIONS_ALL) {
+        std::cout << "Instructions not used by tests:" << std::endl;
         for (auto instruction : instructions_not_used) {
             std::cout << instruction_to_name(instruction) << std::endl;
         }
     }
+
     return test_results;
 }

--- a/src/runner.cc
+++ b/src/runner.cc
@@ -36,16 +36,15 @@ int
 main(int argc, char** argv)
 {
     try {
-        std::set<uint8_t> opcodes_used;
-        std::set<uint8_t> opcodes_not_used;
-
         boost::program_options::options_description desc("Options");
         desc.add_options()("help", "Print help messages")(
             "test_file_path", boost::program_options::value<std::string>(), "Path to test file")(
             "test_file_directory", boost::program_options::value<std::string>(), "Path to test file directory")(
             "plugin_path", boost::program_options::value<std::string>(), "Path to plugin")(
             "plugin_options", boost::program_options::value<std::string>(), "Options to pass to plugin")(
-            "list_instructions", boost::program_options::value<bool>(), "List instructions used in tests")(
+            "list_instructions", boost::program_options::value<bool>(), "List instructions used and not used in tests")(
+            "list_used_instructions", boost::program_options::value<bool>(), "List instructions used in tests")(
+            "list_unused_instructions", boost::program_options::value<bool>(), "List instructions not used in tests")(
             "debug", boost::program_options::value<bool>(), "Print debug information")(
             "cpu_version", boost::program_options::value<std::string>(), "CPU version")(
             "include_regex", boost::program_options::value<std::string>(), "Include regex")(
@@ -110,7 +109,18 @@ main(int argc, char** argv)
         size_t tests_run = 0;
         bool show_instructions = vm.count("list_instructions") ? vm["list_instructions"].as<bool>() : false;
         bool debug = vm.count("debug") ? vm["debug"].as<bool>() : false;
-        auto test_results = bpf_conformance(tests, plugin_path, plugin_options, include_regex, exclude_regex, CPU_version, show_instructions, debug);
+        bool list_used_instructions = vm.count("list_used_instructions") ? vm["list_used_instructions"].as<bool>() : false;
+        bool list_unused_instructions = vm.count("list_unused_instructions") ? vm["list_unused_instructions"].as<bool>() : false;
+        bpf_conformance_list_instructions_t list_instructions = bpf_conformance_list_instructions_t::LIST_INSTRUCTIONS_NONE;
+        if (show_instructions) {
+            list_instructions = bpf_conformance_list_instructions_t::LIST_INSTRUCTIONS_ALL;
+        } else if (list_used_instructions) {
+            list_instructions = bpf_conformance_list_instructions_t::LIST_INSTRUCTIONS_USED;
+        } else if (list_unused_instructions) {
+            list_instructions = bpf_conformance_list_instructions_t::LIST_INSTRUCTIONS_UNUSED;
+        }
+
+        auto test_results = bpf_conformance(tests, plugin_path, plugin_options, include_regex, exclude_regex, CPU_version, list_instructions, debug);
 
         // At the end of all the tests, print a summary of the results.
         std::cout << "Test results:" << std::endl;


### PR DESCRIPTION
Add option to display either used or unused instructions.
Resolves: #58 

Signed-off-by: Alan Jowett <alanjo@microsoft.com>