### PR TITLE
Add support for extended call instructions

### DIFF
--- a/src/bpf_assembler.cc
+++ b/src/bpf_assembler.cc
@@ -287,8 +287,7 @@ typedef class _bpf_assembler
             if (mode == "helper") {
                 inst.imm = _decode_imm32(target);
                 inst.src = 0;
-            }
-            else if (mode == "local") {
+            } else if (mode == "local") {
                 inst.imm == _decode_jump_target(target);
                 inst.src = 1;
             } else if (mode == "runtime") {
@@ -582,8 +581,7 @@ typedef class _bpf_assembler
             }
             if (output[i].opcode == EBPF_OP_CALL) {
                 output[i].imm = static_cast<uint16_t>(iter->second - i - 1);
-            }
-            else {
+            } else {
                 output[i].offset = static_cast<uint16_t>(iter->second - i - 1);
             }
         }

--- a/src/bpf_assembler.cc
+++ b/src/bpf_assembler.cc
@@ -281,7 +281,22 @@ typedef class _bpf_assembler
             inst.opcode = EBPF_OP_EXIT;
         } else if (mnemonic == "call") {
             inst.opcode = EBPF_OP_CALL;
-            inst.imm = _decode_imm32(operands[0]);
+            auto mode = operands[0];
+            auto target = operands[1];
+            // Mode determines if this is a helper function, a local call, or a call to a runtime function.
+            if (mode == "helper") {
+                inst.imm = _decode_imm32(target);
+                inst.src = 0;
+            }
+            else if (mode == "local") {
+                inst.imm == _decode_jump_target(target);
+                inst.src = 1;
+            } else if (mode == "runtime") {
+                inst.imm = _decode_imm32(target);
+                inst.src = 2;
+            } else {
+                throw std::runtime_error("Invalid call mode");
+            }
         } else {
             mnemonic.ends_with("32") ? inst.opcode = EBPF_CLS_JMP32 : inst.opcode |= EBPF_CLS_JMP;
             auto iter =
@@ -408,7 +423,7 @@ typedef class _bpf_assembler
         {"and", {&_bpf_assembler::_encode_alu, 2}},   {"and32", {&_bpf_assembler::_encode_alu, 2}},
         {"arsh", {&_bpf_assembler::_encode_alu, 2}},  {"arsh32", {&_bpf_assembler::_encode_alu, 2}},
         {"be16", {&_bpf_assembler::_encode_alu, 1}},  {"be32", {&_bpf_assembler::_encode_alu, 1}},
-        {"be64", {&_bpf_assembler::_encode_alu, 1}},  {"call", {&_bpf_assembler::_encode_jmp, 1}},
+        {"be64", {&_bpf_assembler::_encode_alu, 1}},  {"call", {&_bpf_assembler::_encode_jmp, 2}},
         {"div", {&_bpf_assembler::_encode_alu, 2}},   {"div32", {&_bpf_assembler::_encode_alu, 2}},
         {"exit", {&_bpf_assembler::_encode_jmp, 0}},  {"ja", {&_bpf_assembler::_encode_jmp, 1}},
         {"jeq", {&_bpf_assembler::_encode_jmp, 3}},   {"jeq32", {&_bpf_assembler::_encode_jmp, 3}},
@@ -506,6 +521,14 @@ typedef class _bpf_assembler
 
             bpf_encode_t encode = nullptr;
             size_t operand_count = 0;
+
+            // If this is a call instruction and it doesn't specify a mode, add the default mode (helper).
+            if (mnemonic == "call") {
+                if (operands.size() == 1) {
+                    operands.insert(operands.begin(), "helper");
+                }
+            }
+
             if (mnemonic == "lock") {
                 // Find the handler for this atomic operation.
                 if (operands.size() == 0) {
@@ -557,7 +580,12 @@ typedef class _bpf_assembler
             if (iter == _labels.end()) {
                 throw std::runtime_error(std::string("Invalid label: ") + _jump_instructions[i].value());
             }
-            output[i].offset = static_cast<uint16_t>(iter->second - i - 1);
+            if (output[i].opcode == EBPF_OP_CALL) {
+                output[i].imm = static_cast<uint16_t>(iter->second - i - 1);
+            }
+            else {
+                output[i].offset = static_cast<uint16_t>(iter->second - i - 1);
+            }
         }
         return output;
     }

--- a/tests/call_local.data
+++ b/tests/call_local.data
@@ -1,0 +1,45 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+-- asm
+# r1-r5 are passed to the callee
+mov r0, 0
+mov r1, 1
+mov r2, 2
+mov r3, 3
+mov r4, 4
+mov r5, 5
+# r6-r9 are preserved
+mov r6, 6
+mov r7, 7
+mov r8, 8
+mov r9, 9
+call local func1
+# r0 contains the return value
+# r0 should contain 1 + 2 + 3 + 4 + 5
+jne r0, 15, failed
+# r6 through r9 should be preserved
+jne r6, 6, failed
+jne r7, 7, failed
+jne r8, 8, failed
+jne r9, 9, failed
+# Success
+mov r0, 1
+exit
+failed:
+mov r0, -1
+exit
+# Function sets r0 = r1 + r2 + r3 + r4 + r5
+func1:
+mov r0, 0
+add r0, r1
+add r0, r2
+add r0, r3
+add r0, r4
+add r0, r5
+mov r6, 0
+mov r7, 0
+mov r8, 0
+mov r9, 0
+exit
+-- result
+0x1


### PR DESCRIPTION
Add support for mnemonic modifiers on call instruction.  Modifiers include:
1) helper - Treat this like a call to a helper function.
2) local - This is an offset to another function in the BPF program.
3) runtime - This is a runtime function.

Resolves: #60

Added tests for local. Tests for runtime functions are still TBD as its unclear what valid values are for runtime function ids.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>