### PR TITLE
Fix v2 ABI to exclude local and runtime calls

### DIFF
--- a/src/bpf_conformance.cc
+++ b/src/bpf_conformance.cc
@@ -139,6 +139,13 @@ bpf_conformance(
                     required_cpu_version = std::max(required_cpu_version, bpf_conformance_test_CPU_version_t::v2);
                 }
             }
+            // If the program uses local or runtime calls then this is v3 of the ABI.
+            // inst.src == 0 means helper function call.
+            // inst.src == 1 means local function call.
+            // inst.src == 2 means runtime function call.
+            if (inst.opcode == EBPF_OP_CALL && inst.src != 0) {
+                required_cpu_version = std::max(required_cpu_version, bpf_conformance_test_CPU_version_t::v3);
+            }
             if (inst.opcode == EBPF_OP_LDDW) {
                 // Instruction has a 64-bit immediate and takes two instructions slots.
                 i++;


### PR DESCRIPTION
The v2 definition of the ABI excludes local and runtime calls. Add option to exclude these when caller requests testing v2 behavior.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>