### PR TITLE
Fix 32-bit jump tests

### DIFF
--- a/tests/jge32-imm.data
+++ b/tests/jge32-imm.data
@@ -10,8 +10,8 @@ jge32 r1, 0xb, exit # Not taken
 
 mov32 r0, 1
 # set r1 to 0x10000000c
-or r1, r9
 mov32 r1, 0xc
+or r1, r9
 jge32 r1, 0xb, exit # Taken
 
 mov32 r0, 2 # Skipped

--- a/tests/jge32-reg.data
+++ b/tests/jge32-reg.data
@@ -11,8 +11,8 @@ jge32 r1, r2, exit # Not taken
 
 mov32 r0, 1
 # set r1 to 0x10000000c
-or r1, r9
 mov32 r1, 0xc
+or r1, r9
 jge32 r1, r2, exit # Taken
 
 mov32 r0, 2 # Skipped


### PR DESCRIPTION
Resolves: #67 

Fix jge32-imm and jge32-reg tests to correctly verify that upper 32 bits are ignored.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>