### PR TITLE
Remove usage of deprecated libbpf API

### DIFF
--- a/libbpf_plugin/CMakeLists.txt
+++ b/libbpf_plugin/CMakeLists.txt
@@ -6,6 +6,16 @@ set(CMAKE_CXX_STANDARD 20)
 include_directories(${LIBBPF_INCLUDE_DIRS})
 link_directories(${LIBBPF_LIBRARIES})
 
+include(CheckSymbolExists)
+
+set(CMAKE_REQUIRED_INCLUDES ${LIBBPF_INCLUDE_DIRS})
+set(CMAKE_REQUIRED_LIBRARIES ${LIBBPF_LIBRARIES})
+check_symbol_exists(bpf_prog_load "bpf/bpf.h" HAS_BPF_PROG_LOAD)
+
+if(NOT HAS_BPF_PROG_LOAD)
+  add_compile_definitions(USE_DEPRECATED_LOAD_PROGRAM)
+endif()
+
 add_executable(
   libbpf_plugin
   libbpf_plugin.cc

--- a/tests/lock_fetch_add.data
+++ b/tests/lock_fetch_add.data
@@ -5,7 +5,7 @@ lddw r0, 0x123456789abcdef0
 stxdw [r10-8], r0
 mov r1, 1
 lock fetch add [r10-8], r1
-jne r1, r0
+jne r1, r0, exit
 ldxdw r1, [r10-8]
 lddw r0, 0x123456789abcdef1
 jne r0, r1, exit


### PR DESCRIPTION
`bpf_load_program` (replaced by `bpf_prog_load`) and `bpf_prog_test_run` (replaced by `bpf_prog_test_run_opts`, which is available since v0.4) are deprecated and finally removed from libbpf v1.0. So the code just does not compile with v1.0.

However, the recommended API `bpf_prog_load` is not available until around v0.7. As [Ubuntu 22.04](https://packages.ubuntu.com/jammy/libbpf-dev) packages libbpf v0.5, it doesn't seem plausible to totally remove the deprecated usage, but I haven’t come up with a good way to test the `bpf_prog_load` branch with GitHub Actions.

Signed-off-by: Shenghui Ye <yesh@aliyun.com>