### PR TITLE
Typo fix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,14 @@ target_include_directories("bpf_conformance_runner" PRIVATE
 target_link_libraries(bpf_conformance PRIVATE ${PLATFORM_LIB})
 target_link_libraries(bpf_conformance_runner PRIVATE ${PLATFORM_LIB} "bpf_conformance")
 
+if(MSVC)
+  target_compile_options(bpf_conformance PRIVATE /W4)
+  target_compile_options(bpf_conformance_runner PRIVATE /W4)
+else()
+  target_compile_options(bpf_conformance PRIVATE -Wall -Wextra -pedantic)
+  target_compile_options(bpf_conformance_runner PRIVATE -Wall -Wextra -pedantic)
+endif()
+
 find_program(ECHO echo)
 
 enable_testing()

--- a/src/bpf_assembler.cc
+++ b/src/bpf_assembler.cc
@@ -614,7 +614,7 @@ typedef class _bpf_assembler
                 throw std::runtime_error(std::string("Invalid label: ") + _jump_instructions[i].value());
             }
             if (output[i].opcode == EBPF_OP_CALL) {
-                output[i].imm = static_cast<uint16_t>(iter->second - i - 1);
+                output[i].imm = static_cast<uint32_t>(iter->second - i - 1);
             } else {
                 output[i].offset = static_cast<uint16_t>(iter->second - i - 1);
             }

--- a/src/bpf_assembler.cc
+++ b/src/bpf_assembler.cc
@@ -288,7 +288,7 @@ typedef class _bpf_assembler
                 inst.imm = _decode_imm32(target);
                 inst.src = 0;
             } else if (mode == "local") {
-                inst.imm == _decode_jump_target(target);
+                inst.imm = _decode_jump_target(target);
                 inst.src = 1;
             } else if (mode == "runtime") {
                 inst.imm = _decode_imm32(target);

--- a/src/bpf_assembler.cc
+++ b/src/bpf_assembler.cc
@@ -153,7 +153,7 @@ typedef class _bpf_assembler
     }
 
     bpf_encode_result_t
-    _encode_ld(const std::string& mnemonic, const std::vector<std::string>& operands)
+    _encode_ld([[maybe_unused]] const std::string& mnemonic, const std::vector<std::string>& operands)
     {
         std::array<ebpf_inst, 2> inst{};
         inst[0].opcode = EBPF_OP_LDDW;

--- a/src/bpf_conformance.cc
+++ b/src/bpf_conformance.cc
@@ -43,7 +43,7 @@ _ebpf_inst_to_byte_vector(const std::vector<ebpf_inst>& instructions)
     std::vector<uint8_t> result;
     for (auto instruction : instructions) {
         uint8_t* instruction_bytes = reinterpret_cast<uint8_t*>(&instruction);
-        for (int i = 0; i < sizeof(ebpf_inst); i++) {
+        for (size_t i = 0; i < sizeof(ebpf_inst); i++) {
             result.push_back(instruction_bytes[i]);
         }
     }
@@ -68,6 +68,9 @@ log_debug_result(
         break;
     case bpf_conformance_test_result_t::TEST_RESULT_ERROR:
         std::cout << "Test " << test << " error: " << message << std::endl;
+        break;
+    case bpf_conformance_test_result_t::TEST_RESULT_UNKNOWN:
+        std::cout << "Test " << test << " result unknown: " << message << std::endl;
         break;
     }
 }


### PR DESCRIPTION
Mainly, it fixes the following typos and adjusts cmake config.

```diff
-                inst.imm == _decode_jump_target(target);
+                inst.imm = _decode_jump_target(target);
```

```diff
-                output[i].imm = static_cast<uint16_t>(iter->second - i - 1);
+                output[i].imm = static_cast<uint32_t>(iter->second - i - 1);
```