### PR TITLE
Add option to pass an ELF file to the plugin instead of an array of BPF byte code

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -39,6 +39,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
 
     - name: Install prerequisites - Ubuntu-22.04
       if: inputs.platform == 'ubuntu-22.04'
@@ -126,7 +128,7 @@ jobs:
       if: inputs.enable_coverage == true
       run: |
         mkdir -p coverage
-        lcov --capture --directory build --include '${{github.workspace}}/*' --output-file coverage/lcov.info
+        lcov --capture --directory build --include '${{github.workspace}}/*' --output-file coverage/lcov.info --exclude '${{github.workspace}}/external/*'
 
     - name: Coveralls Parallel
       if: inputs.enable_coverage == true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/elfio"]
+	path = external/elfio
+	url = https://github.com/serge1/ELFIO.git

--- a/include/bpf_conformance.h
+++ b/include/bpf_conformance.h
@@ -17,12 +17,12 @@ typedef enum class _bpf_conformance_test_result
     TEST_RESULT_UNKNOWN
 } bpf_conformance_test_result_t;
 
-typedef enum class _bpf_conformance_test_CPU_version
+typedef enum class _bpf_conformance_test_cpu_version
 {
     v1 = 1,
     v2 = 2,
     v3 = 3,
-} bpf_conformance_test_CPU_version_t;
+} bpf_conformance_test_cpu_version_t;
 
 typedef enum class _bpf_conformance_list_instructions
 {
@@ -32,6 +32,34 @@ typedef enum class _bpf_conformance_list_instructions
     LIST_INSTRUCTIONS_ALL,    // List all instructions.
 } bpf_conformance_list_instructions_t;
 
+typedef struct _bpf_conformance_options
+{
+    std::optional<std::string> include_test_regex;
+    std::optional<std::string> exclude_test_regex;
+    bpf_conformance_test_cpu_version_t cpu_version;
+    bpf_conformance_list_instructions_t list_instructions_option;
+    bool debug;
+    bool xdp_prolog;
+    bool elf_format;
+} bpf_conformance_options_t;
+
+/**
+ * @brief Run the BPF conformance tests with the given plugin.
+ *
+ * @param[in] test_files List of test files to run.
+ * @param[in] plugin_path The path to the plugin to run the tests with.
+ * @param[in] plugin_options The options to pass to the plugin.
+ * @param[in] options Options controlling the behavior of the tests.
+ * @return The test results for each test file.
+ */
+std::map<std::filesystem::path, std::tuple<bpf_conformance_test_result_t, std::string>>
+bpf_conformance_options(
+    const std::vector<std::filesystem::path>& test_files,
+    const std::filesystem::path& plugin_path,
+    const std::vector<std::string>& plugin_options,
+    const bpf_conformance_options_t& options);
+
+// Backwards compatibility wrapper.
 /**
  * @brief Run the BPF conformance tests with the given plugin.
  *
@@ -40,19 +68,28 @@ typedef enum class _bpf_conformance_list_instructions
  * @param[in] plugin_options The options to pass to the plugin.
  * @param[in] include_test_regex A regex that matches the tests to include.
  * @param[in] exclude_test_regex A regex that matches the tests to exclude.
- * @param[in] CPU_version The CPU version to run the tests with.
+ * @param[in] cpu_version The CPU version to run the tests with.
  * @param[in] list_instructions_option Option controlling which instructions to list.
  * @param[in] debug Print debug information.
  * @return The test results for each test file.
  */
-std::map<std::filesystem::path, std::tuple<bpf_conformance_test_result_t, std::string>>
+[[deprecated]] inline std::map<std::filesystem::path, std::tuple<bpf_conformance_test_result_t, std::string>>
 bpf_conformance(
     const std::vector<std::filesystem::path>& test_files,
     const std::filesystem::path& plugin_path,
     const std::vector<std::string>& plugin_options,
     std::optional<std::string> include_test_regex = std::nullopt,
     std::optional<std::string> exclude_test_regex = std::nullopt,
-    bpf_conformance_test_CPU_version_t CPU_version = bpf_conformance_test_CPU_version_t::v3,
+    bpf_conformance_test_cpu_version_t cpu_version = bpf_conformance_test_cpu_version_t::v3,
     bpf_conformance_list_instructions_t list_instructions_option =
         bpf_conformance_list_instructions_t::LIST_INSTRUCTIONS_NONE,
-    bool debug = false);
+    bool debug = false)
+{
+    bpf_conformance_options_t options;
+    options.include_test_regex = include_test_regex;
+    options.exclude_test_regex = exclude_test_regex;
+    options.cpu_version = cpu_version;
+    options.list_instructions_option = list_instructions_option;
+    options.debug = debug;
+    return bpf_conformance_options(test_files, plugin_path, plugin_options, options);
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,13 +34,15 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   set(Boost_LIBRARY_DIRS ${CMAKE_BINARY_DIR}/packages/boost_filesystem-vc${MSVC_PLATFORM}/lib/native ${CMAKE_BINARY_DIR}/packages/boost_program_options-vc${MSVC_PLATFORM}/lib/native)
 endif()
 
-include_directories(${Boost_INCLUDE_DIR})
+include_directories(${Boost_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/external/elfio)
+
 link_directories(${Boost_LIBRARY_DIRS})
 
 add_library("bpf_conformance"
   bpf_assembler.cc
   bpf_test_parser.cc
   bpf_conformance.cc
+  bpf_writer.cc
 )
 
 add_executable(
@@ -75,22 +77,27 @@ enable_testing()
 
 add_test(
   NAME cpu_v1
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${CMAKE_BINARY_DIR}/tests --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --cpu_version v1
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${CMAKE_BINARY_DIR}/tests --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v1
 )
 
 add_test(
   NAME cpu_v2
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${CMAKE_BINARY_DIR}/tests --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --cpu_version v2
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${CMAKE_BINARY_DIR}/tests --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v2
 )
 
 add_test(
   NAME cpu_v3
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${CMAKE_BINARY_DIR}/tests --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --cpu_version v3 --debug true --list_instructions true
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${CMAKE_BINARY_DIR}/tests --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v3 --debug true --list_instructions true
+)
+
+add_test(
+  NAME elf_format
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${CMAKE_BINARY_DIR}/tests --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --debug true --list_instructions true --elf true --exclude_regex "call_local*"
 )
 
 add_test(
   NAME no_bpf_bytecode
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_path ${CMAKE_SOURCE_DIR}/negative/empty.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --debug true
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_path ${CMAKE_SOURCE_DIR}/negative/empty.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --debug true
 )
 
 set_tests_properties(
@@ -167,7 +174,7 @@ set_tests_properties(
 
 add_test(
   NAME verifier_failure
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/error.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug"
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/error.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --plugin_options "--debug"
 )
 
 set_tests_properties(
@@ -178,7 +185,7 @@ set_tests_properties(
 
 add_test(
   NAME invalid_register
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_register.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug"
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_register.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --plugin_options "--debug"
 )
 
 set_tests_properties(
@@ -189,7 +196,7 @@ set_tests_properties(
 
 add_test(
   NAME invalid_offset
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_offset.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug"
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_offset.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --plugin_options "--debug"
 )
 
 set_tests_properties(
@@ -200,7 +207,7 @@ set_tests_properties(
 
 add_test(
   NAME invalid_operand_count
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_operand_count.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug"
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_operand_count.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --plugin_options "--debug"
 )
 
 set_tests_properties(
@@ -211,7 +218,7 @@ set_tests_properties(
 
 add_test(
   NAME invalid_label
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_label.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug"
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_label.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --plugin_options "--debug"
 )
 
 set_tests_properties(
@@ -222,7 +229,7 @@ set_tests_properties(
 
 add_test(
   NAME invalid_mnemonic
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_mnemonic.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug"
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_mnemonic.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --plugin_options "--debug"
 )
 
 set_tests_properties(
@@ -244,7 +251,7 @@ set_tests_properties(
 
 add_test(
   NAME invalid_lock
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_lock.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug" 2>&1
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_lock.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --plugin_options "--debug" 2>&1
 )
 
 set_tests_properties(
@@ -255,7 +262,7 @@ set_tests_properties(
 
 add_test(
   NAME invalid_lock2
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_lock2.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug"
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_lock2.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --plugin_options "--debug"
   )
 
 set_tests_properties(
@@ -266,7 +273,7 @@ set_tests_properties(
 
 add_test(
   NAME include_test
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/tests/lock_add.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug" --include_regex lock
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/tests/lock_add.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --plugin_options "--debug" --include_regex lock
 )
 
 set_tests_properties(
@@ -277,7 +284,7 @@ set_tests_properties(
 
 add_test(
   NAME exclude_test
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/tests/lock_add.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug" --exclude_regex lock
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/tests/lock_add.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --plugin_options "--debug" --exclude_regex lock
 )
 
 set_tests_properties(
@@ -288,7 +295,7 @@ set_tests_properties(
 
 add_test(
   NAME negative_include_test
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/tests/lock_add.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug" --include_regex clock
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/tests/lock_add.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --plugin_options "--debug" --include_regex clock
 )
 
 set_tests_properties(
@@ -299,7 +306,7 @@ set_tests_properties(
 
 add_test(
   NAME negative_exclude_test
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/tests/lock_add.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug" --exclude_regex clock
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/tests/lock_add.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --plugin_options "--debug" --exclude_regex clock
 )
 
 add_test(
@@ -337,7 +344,7 @@ set_tests_properties(
 
 add_test(
   NAME invalid_cpu_version
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_path ${CMAKE_SOURCE_DIR}/tests/lock_add.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --cpu_version not_a_version
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_path ${CMAKE_SOURCE_DIR}/tests/lock_add.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version not_a_version
 )
 
 set_tests_properties(
@@ -359,7 +366,7 @@ set_tests_properties(
 
 add_test(
   NAME fail_with_error
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_path ${CMAKE_SOURCE_DIR}/tests/add.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--help" --debug true
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_path ${CMAKE_SOURCE_DIR}/tests/add.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --plugin_options "--help" --debug true
 )
 
 set_tests_properties(
@@ -370,7 +377,7 @@ set_tests_properties(
 
 add_test(
   NAME unknown_directive
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_unknown_directive.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --plugin_options "--debug"
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --debug true --test_file_path ${CMAKE_SOURCE_DIR}/negative/invalid_unknown_directive.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --plugin_options "--debug"
 )
 
 set_tests_properties(
@@ -403,7 +410,7 @@ set_tests_properties(
 
 add_test(
   NAME list_used_instructions
-  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${CMAKE_BINARY_DIR}/tests --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --cpu_version v1 --list_used_instructions true
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${CMAKE_BINARY_DIR}/tests --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v1 --list_used_instructions true
 )
 
 set_tests_properties(

--- a/src/bpf_assembler.cc
+++ b/src/bpf_assembler.cc
@@ -156,6 +156,8 @@ typedef class _bpf_assembler
     _encode_ld([[maybe_unused]] const std::string& mnemonic, const std::vector<std::string>& operands)
     {
         std::array<ebpf_inst, 2> inst{};
+        // Issue: https://github.com/Alan-Jowett/bpf_conformance/issues/59
+        // Add support for other 64-bit immediate values.
         inst[0].opcode = EBPF_OP_LDDW;
         inst[0].dst = _decode_register(operands[0]);
         uint64_t immediate = _decode_imm64(operands[1]);

--- a/src/bpf_assembler.h
+++ b/src/bpf_assembler.h
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include <iostream>
 #include <string>
 #include <vector>
-#include <iostream>
 #include "ebpf.h"
 
 /**

--- a/src/bpf_writer.cc
+++ b/src/bpf_writer.cc
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include <elfio/elfio.hpp>
+
+#include "bpf_writer.h"
+
+const std::string symbol_section_name = ".symtab";
+// https://github.com/Alan-Jowett/bpf_conformance/issues/82
+// Add support for the new BTF based .maps section.
+const std::string maps_section_name = "maps";
+const std::string relocation_prefix = ".rel";
+
+void
+bpf_writer_classic(
+    std::ostream& output,
+    const std::string& section_name,
+    const std::string& function_name,
+    const std::vector<ebpf_inst_t>& instructions,
+    const std::vector<std::tuple<std::string, ebpf_map_definition_in_file_t>>& maps,
+    const std::map<size_t, std::string>& map_relocations)
+{
+    ELFIO::elfio writer;
+    writer.create(ELFIO::ELFCLASS64, ELFIO::ELFDATA2LSB);
+
+    writer.set_type(ELFIO::ET_REL);
+    writer.set_machine(ELFIO::EM_BPF);
+
+    auto symbols_section = writer.sections.add(symbol_section_name);
+    symbols_section->set_type(ELFIO::SHT_SYMTAB);
+    symbols_section->set_flags(0);
+    symbols_section->set_addr_align(4);
+    symbols_section->set_info(1);
+    symbols_section->set_entry_size(writer.get_default_entry_size(ELFIO::SHT_SYMTAB));
+    symbols_section->set_link(writer.get_section_name_str_index());
+
+    auto text_section = writer.sections.add(section_name);
+    text_section->set_type(ELFIO::SHT_PROGBITS);
+    text_section->set_flags(ELFIO::SHF_EXECINSTR | ELFIO::SHF_ALLOC);
+    text_section->set_addr_align(4);
+    text_section->append_data(
+        reinterpret_cast<const char*>(instructions.data()),
+        static_cast<ELFIO::Elf_Word>(instructions.size() * sizeof(ebpf_inst_t)));
+
+    auto string_accessor = ELFIO::string_section_accessor(writer.sections[writer.get_section_name_str_index()]);
+    auto symbol_accessor = ELFIO::symbol_section_accessor(writer, symbols_section);
+
+    symbol_accessor.add_symbol(
+        string_accessor,
+        function_name.c_str(),
+        text_section->get_address(),
+        text_section->get_size(),
+        ELFIO::STB_GLOBAL,
+        ELFIO::STT_FUNC,
+        0,
+        text_section->get_index());
+
+    if (maps.size() > 0) {
+        auto relocation_section = writer.sections.add(relocation_prefix + section_name);
+        auto maps_section = writer.sections.add(maps_section_name);
+        maps_section->set_type(ELFIO::SHT_PROGBITS);
+        maps_section->set_flags(ELFIO::SHF_WRITE | ELFIO::SHF_ALLOC);
+        maps_section->set_addr_align(4);
+        for (const auto& map : maps) {
+            maps_section->append_data(
+                reinterpret_cast<const char*>(&std::get<1>(map)), sizeof(ebpf_map_definition_in_file_t));
+        }
+
+        relocation_section->set_type(ELFIO::SHT_REL);
+        relocation_section->set_flags(0);
+        relocation_section->set_addr_align(8);
+        relocation_section->set_info(text_section->get_index());
+        relocation_section->set_link(symbols_section->get_index());
+        relocation_section->set_entry_size(writer.get_default_entry_size(ELFIO::SHT_REL));
+
+        auto relocation_accessor = ELFIO::relocation_section_accessor(writer, relocation_section);
+
+        for (const auto& relocation : map_relocations) {
+            auto map_entry = std::find_if(
+                maps.begin(), maps.end(), [&](const auto& map) { return std::get<0>(map) == relocation.second; });
+            if (map_entry == maps.end()) {
+                throw std::runtime_error("Map not found");
+            }
+            size_t map_offset = std::distance(maps.begin(), map_entry) * sizeof(ebpf_map_definition_in_file_t);
+            relocation_accessor.add_entry(
+                string_accessor,
+                relocation.second.c_str(),
+                symbol_accessor,
+                map_offset,
+                sizeof(ebpf_map_definition_in_file_t),
+                ELFIO::STB_GLOBAL << 4 | ELFIO::STT_OBJECT,
+                0,
+                maps_section->get_index(),
+                relocation.first * sizeof(ebpf_inst_t),
+                ELFIO::R_X86_64_64);
+        }
+    }
+
+    writer.save(output);
+}

--- a/src/bpf_writer.h
+++ b/src/bpf_writer.h
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#pragma once
+#include <iostream>
+#include <map>
+#include <string>
+#include <tuple>
+#include <vector>
+#include "ebpf.h"
+
+/**
+ * @brief Write a BPF program to an ELF file, using the classic ELF format for maps.
+ *
+ * @param[out] output Stream to write the ELF file to.
+ * @param[in] instructions BPF instructions to write.
+ * @param[in] maps BPF maps to write.
+ * @param[in] map_relocations Map of map names to their relocations.
+ */
+void
+bpf_writer_classic(
+    std::ostream& output,
+    const std::string& section_name,
+    const std::string& function_name,
+    const std::vector<ebpf_inst_t>& instructions,
+    const std::vector<std::tuple<std::string, ebpf_map_definition_in_file_t>>& maps,
+    const std::map<size_t, std::string>& map_relocations);

--- a/src/ebpf.h
+++ b/src/ebpf.h
@@ -24,14 +24,14 @@
 
 /* eBPF definitions */
 
-struct ebpf_inst
+typedef struct ebpf_inst
 {
     uint8_t opcode;
     uint8_t dst : 4;
     uint8_t src : 4;
     int16_t offset;
     int32_t imm;
-};
+} ebpf_inst_t;
 
 #define EBPF_CLS_MASK 0x07
 #define EBPF_ALU_OP_MASK 0xf0
@@ -216,5 +216,17 @@ struct ebpf_inst
 
 #define EBPF_OP_ATOMIC32_STORE (EBPF_CLS_STX | EBPF_MODE_ATOMIC | EBPF_SIZE_W)
 #define EBPF_OP_ATOMIC_STORE (EBPF_CLS_STX | EBPF_MODE_ATOMIC | EBPF_SIZE_DW)
+
+/**
+ * @brief eBPF Map Definition as it appears in the maps section of an ELF file.
+ */
+typedef struct _ebpf_map_definition_in_file
+{
+    uint32_t type;          ///< Type of map.
+    uint32_t key_size;      ///< Size in bytes of a map key.
+    uint32_t value_size;    ///< Size in bytes of a map value.
+    uint32_t max_entries;   ///< Maximum number of entries allowed in the map.
+    uint32_t inner_map_idx; ///< Index of inner map if this is a nested map.
+} ebpf_map_definition_in_file_t;
 
 #endif


### PR DESCRIPTION
Add option to pass an ELF file to the plugin instead of an array of BPF byte code.

This is a prerequisite for fixing #59 as we need to pass maps and relocation info to the plugin.