### PR TITLE
Make sure tests always maintain Linux style linefeed

### DIFF
--- a/src/bpf_test_parser.cc
+++ b/src/bpf_test_parser.cc
@@ -31,6 +31,10 @@ parse_test_file(const std::filesystem::path& data_file)
     std::string raw;
 
     while (std::getline(data_in, line)) {
+        // Strip trailing carriage return
+        if (line.back() == '\r') {
+            line.pop_back();
+        }
         if (line.find("--") != std::string::npos) {
             if (line.find("asm") != std::string::npos) {
                 state = _state::state_assembly;


### PR DESCRIPTION
Make sure tests always maintain Linux style linefeed.

Resolves: #84 

Signed-off-by: Alan Jowett <alanjo@microsoft.com>