### PR TITLE
Test bpf_conformance and bpf_conformance_options

### DIFF
--- a/include/bpf_conformance.h
+++ b/include/bpf_conformance.h
@@ -76,7 +76,7 @@ bpf_conformance_options(
  * @param[in] debug Print debug information.
  * @return The test results for each test file.
  */
-[[deprecated]] inline std::map<std::filesystem::path, std::tuple<bpf_conformance_test_result_t, std::string>>
+inline std::map<std::filesystem::path, std::tuple<bpf_conformance_test_result_t, std::string>>
 bpf_conformance(
     const std::vector<std::filesystem::path>& test_files,
     const std::filesystem::path& plugin_path,
@@ -88,7 +88,7 @@ bpf_conformance(
         bpf_conformance_list_instructions_t::LIST_INSTRUCTIONS_NONE,
     bool debug = false)
 {
-    bpf_conformance_options_t options;
+    bpf_conformance_options_t options = {};
     options.include_test_regex = include_test_regex;
     options.exclude_test_regex = exclude_test_regex;
     options.cpu_version = cpu_version;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -429,3 +429,8 @@ set_tests_properties(
   PROPERTIES
   PASS_REGULAR_EXPRESSION "Instructions not used by tests"
 )
+
+add_test(
+  NAME back_compat
+  COMMAND sudo ${CMAKE_BINARY_DIR}/bin/bpf_conformance_runner --test_file_path ${CMAKE_BINARY_DIR}/tests/add.data --plugin_path ${CMAKE_BINARY_DIR}/bin/libbpf_plugin
+)

--- a/src/runner.cc
+++ b/src/runner.cc
@@ -164,7 +164,13 @@ main(int argc, char** argv)
         options.xdp_prolog = xdp_prolog;
         options.elf_format = elf_format;
 
-        auto test_results = bpf_conformance_options(tests, plugin_path, plugin_options, options);
+        std::map<std::filesystem::path, std::tuple<bpf_conformance_test_result_t, std::string>> test_results;
+        if (options.elf_format == false && options.xdp_prolog == false) {
+            test_results = bpf_conformance(tests, plugin_path, plugin_options, include_regex, exclude_regex, cpu_version, list_instructions, debug);
+        }
+        else {
+            test_results = bpf_conformance_options(tests, plugin_path, plugin_options, options);
+        }
 
         // At the end of all the tests, print a summary of the results.
         std::cout << "Test results:" << std::endl;


### PR DESCRIPTION
Add missing test case for the older bpf_conformance API.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>