### PR TITLE
Switch to gcc register format

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This project measures the conformance of a BPF runtime to the ISA. To measure conformance the BPF runtime under test is built into a plugin process that does:
 1) Accept both BPF byte code an initial memory.
 2) Execute the byte code.
-3) Return the value in r0 at the end of the execution.
+3) Return the value in %r0 at the end of the execution.
 
 ## eBPF runtime implementations that are currently measured using this project
 1) [Linux Kernel via libbpf](https://github.com/Alan-Jowett/bpf_conformance/tree/main/libbpf_plugin)

--- a/libbpf_plugin/libbpf_plugin.cc
+++ b/libbpf_plugin/libbpf_plugin.cc
@@ -3,7 +3,7 @@
 
 // This program reads BPF instructions from stdin and memory contents from
 // the first argument. It then executes the BPF program and prints the
-// value of r0 at the end of execution.
+// value of %r0 at the end of execution.
 // The program is intended to be used with the bpf conformance test suite.
 
 #include <cstring>
@@ -131,7 +131,7 @@ int load_elf_file(const std::string& file_contents, std::string& log)
 /**
  * @brief This program reads BPF instructions from stdin and memory contents from
  * the first argument. It then executes the BPF program and prints the
- * value of r0 at the end of execution.
+ * value of %r0 at the end of execution.
  */
 int
 main(int argc, char** argv)

--- a/negative/error.data
+++ b/negative/error.data
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-or r0, r10
+or %r0, %r10
 exit
 -- error
 Invalid

--- a/negative/invalid_lock.data
+++ b/negative/invalid_lock.data
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lock or [r10-8]
+lock or [%r10-8]
 exit
 -- error
 Invalid number of operands for lock

--- a/negative/invalid_mnemonic.data
+++ b/negative/invalid_mnemonic.data
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 -- asm
 # Invalid mnemonic
-ldxq r0, r1
+ldxq %r0, %r1
 exit
 -- result
 0x11

--- a/negative/invalid_offset.data
+++ b/negative/invalid_offset.data
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-ldxb r0, r1
+ldxb %r0, %r1
 exit
 -- result
 0x11

--- a/negative/invalid_operand_count.data
+++ b/negative/invalid_operand_count.data
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0
+lddw %r0
 exit
 -- result
 0x11

--- a/negative/invalid_register.data
+++ b/negative/invalid_register.data
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-or r0, r50
+or %r0, %r50
 exit
 -- error
 Invalid register

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -191,7 +191,7 @@ add_test(
 set_tests_properties(
   invalid_register
   PROPERTIES
-  PASS_REGULAR_EXPRESSION "Invalid register: r50"
+  PASS_REGULAR_EXPRESSION "Invalid register: %r50"
 )
 
 add_test(
@@ -202,7 +202,7 @@ add_test(
 set_tests_properties(
   invalid_offset
   PROPERTIES
-  PASS_REGULAR_EXPRESSION "Failed to decode register and offset: r1"
+  PASS_REGULAR_EXPRESSION "Failed to decode register and offset: %r1"
 )
 
 add_test(

--- a/src/bpf_assembler.cc
+++ b/src/bpf_assembler.cc
@@ -21,23 +21,23 @@ typedef class _bpf_assembler
         const std::string& mnemonic, const std::vector<std::string>& operands);
 
     const std::unordered_map<std::string, int> _bpf_encode_register_map{
-        {"r0", 0},
-        {"r1", 1},
-        {"r2", 2},
-        {"r3", 3},
-        {"r4", 4},
-        {"r5", 5},
-        {"r6", 6},
-        {"r7", 7},
-        {"r8", 8},
-        {"r9", 9},
-        {"r10", 10},
+        {"%r0", 0},
+        {"%r1", 1},
+        {"%r2", 2},
+        {"%r3", 3},
+        {"%r4", 4},
+        {"%r5", 5},
+        {"%r6", 6},
+        {"%r7", 7},
+        {"%r8", 8},
+        {"%r9", 9},
+        {"%r10", 10},
         // Add fake registers to support negative tests.
-        {"r11", 11},
-        {"r12", 12},
-        {"r13", 13},
-        {"r14", 14},
-        {"r15", 15},
+        {"%r11", 11},
+        {"%r12", 12},
+        {"%r13", 13},
+        {"%r14", 14},
+        {"%r15", 15},
     };
 
     const std::unordered_map<std::string, int> _bpf_encode_alu_ops{
@@ -260,7 +260,7 @@ typedef class _bpf_assembler
         inst.dst = _decode_register(operands[0]);
 
         if (operands.size() == 2) {
-            if (operands[1].starts_with('r')) {
+            if (operands[1].starts_with('%')) {
                 inst.opcode |= EBPF_SRC_REG;
                 inst.src = _decode_register(operands[1]);
             } else {
@@ -305,7 +305,7 @@ typedef class _bpf_assembler
             // It is not possible to reach here with no match.
             inst.opcode |= iter->second << 4;
             inst.dst = _decode_register(operands[0]);
-            if (operands[1].starts_with('r')) {
+            if (operands[1].starts_with('%')) {
                 inst.opcode |= EBPF_SRC_REG;
                 inst.src = _decode_register(operands[1]);
             } else {

--- a/src/bpf_conformance.cc
+++ b/src/bpf_conformance.cc
@@ -104,7 +104,7 @@ _log_debug_result(
 }
 
 /**
- * @brief Create a prolog that loads the packet memory into R1 and the length into R2.
+ * @brief Create a prolog that loads the packet memory into %R1 and the length into %R2.
  *
  * @param[in] size Expected size of the packet.
  * @return Vector of bpf_insn that represents the prolog.
@@ -118,19 +118,19 @@ _generate_xdp_prolog(size_t size)
     // Create a prolog that converts the BPF program to one that can be loaded
     // at the XDP attach point.
     // This involves:
-    // 1. Copying the ctx->data into r1.
-    // 2. Copying the ctx->data_end - ctx->data into r2.
-    // 3. Satisfying the verifier that r2 is the length of the packet.
+    // 1. Copying the ctx->data into %r1.
+    // 2. Copying the ctx->data_end - ctx->data into %r2.
+    // 3. Satisfying the verifier that %r2 is the length of the packet.
     return {
-        {0xb7, 0x0, 0x0, 0x0, -1},   // mov64 r0, -1
-        {0xbf, 0x6, 0x1, 0x0, 0x0},  // mov r6, r1
-        {0x61, 0x1, 0x6, 0x0, 0x0},  // ldxw r1, [r6+0]
-        {0x61, 0x2, 0x6, 0x4, 0x0},  // ldxw r2, [r6+4]
-        {0xbf, 0x3, 0x1, 0x0, 0x0},  // mov r3, r1
-        {0x7, 0x3, 0x0, 0x0, static_cast<int>(size)},  // add r3, size
-        {0xbd, 0x3, 0x2, 0x1, 0x0},  //  jle r3, r2, +1
+        {0xb7, 0x0, 0x0, 0x0, -1},   // mov64 %r0, -1
+        {0xbf, 0x6, 0x1, 0x0, 0x0},  // mov %r6, %r1
+        {0x61, 0x1, 0x6, 0x0, 0x0},  // ldxw %r1, [%r6+0]
+        {0x61, 0x2, 0x6, 0x4, 0x0},  // ldxw %r2, [%r6+4]
+        {0xbf, 0x3, 0x1, 0x0, 0x0},  // mov %r3, %r1
+        {0x7, 0x3, 0x0, 0x0, static_cast<int>(size)},  // add %r3, size
+        {0xbd, 0x3, 0x2, 0x1, 0x0},  //  jle %r3, %r2, +1
         {0x95, 0x0, 0x0, 0x0, 0x0},  // exit
-        {0xb7, 0x2, 0x0, 0x0, static_cast<int>(size)}, // mov r2, size
+        {0xb7, 0x2, 0x0, 0x0, static_cast<int>(size)}, // mov %r2, size
     };
 }
 

--- a/tests/add.data
+++ b/tests/add.data
@@ -1,10 +1,10 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov32 r1, 2
-add32 r0, 1
-add32 r0, r1
+mov32 %r0, 0
+mov32 %r1, 2
+add32 %r0, 1
+add32 %r0, %r1
 exit
 -- result
 0x3

--- a/tests/add64.data
+++ b/tests/add64.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 1
-add r0, -1
+mov %r0, 1
+add %r0, -1
 exit
 -- result
 0

--- a/tests/alu-arith.data
+++ b/tests/alu-arith.data
@@ -1,38 +1,38 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov32 r1, 1
-mov32 r2, 2
-mov32 r3, 3
-mov32 r4, 4
-mov32 r5, 5
-mov32 r6, 6
-mov32 r7, 7
-mov32 r8, 8
-mov32 r9, 9
-# r0 == 0
-jne r0, 0, exit
+mov32 %r0, 0
+mov32 %r1, 1
+mov32 %r2, 2
+mov32 %r3, 3
+mov32 %r4, 4
+mov32 %r5, 5
+mov32 %r6, 6
+mov32 %r7, 7
+mov32 %r8, 8
+mov32 %r9, 9
+# %r0 == 0
+jne %r0, 0, exit
 
-add32 r0, 23
-add32 r0, r7
-# r0 == 30
-jne r0, 30, exit
+add32 %r0, 23
+add32 %r0, %r7
+# %r0 == 30
+jne %r0, 30, exit
 
-sub32 r0, 13
-sub32 r0, r1
-# r0 == 16
-jne r0, 16, exit
+sub32 %r0, 13
+sub32 %r0, %r1
+# %r0 == 16
+jne %r0, 16, exit
 
-mul32 r0, 7
-mul32 r0, r3
-# r0 == 336
-jne r0, 336, exit
+mul32 %r0, 7
+mul32 %r0, %r3
+# %r0 == 336
+jne %r0, 336, exit
 
-div32 r0, 2
-div32 r0, r4
-# r0 == 42
-jne r0, 42, exit
+div32 %r0, 2
+div32 %r0, %r4
+# %r0 == 42
+jne %r0, 42, exit
 
 exit
 -- result

--- a/tests/alu-bit.data
+++ b/tests/alu-bit.data
@@ -1,42 +1,42 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov32 r1, 1
-mov32 r2, 2
-mov32 r3, 3
-mov32 r4, 4
-mov32 r5, 5
-mov32 r6, 6
-mov32 r7, 7
-mov32 r8, 8
-# r0 == 0
-jne r0, 0, exit
+mov32 %r0, 0
+mov32 %r1, 1
+mov32 %r2, 2
+mov32 %r3, 3
+mov32 %r4, 4
+mov32 %r5, 5
+mov32 %r6, 6
+mov32 %r7, 7
+mov32 %r8, 8
+# %r0 == 0
+jne %r0, 0, exit
 
-or32 r0, r5
-or32 r0, 0xa0
-# r0 == 0xa5
-jne r0, 0xa5, exit
+or32 %r0, %r5
+or32 %r0, 0xa0
+# %r0 == 0xa5
+jne %r0, 0xa5, exit
 
-and32 r0, 0xa3
-mov32 r9, 0x91
-and32 r0, r9
-# r0 == 0x81
-jne r0, 0x81, exit
+and32 %r0, 0xa3
+mov32 %r9, 0x91
+and32 %r0, %r9
+# %r0 == 0x81
+jne %r0, 0x81, exit
 
-lsh32 r0, 22
-lsh32 r0, r8
-# r0 == 0x40000000
-jne r0, 0x40000000, exit
+lsh32 %r0, 22
+lsh32 %r0, %r8
+# %r0 == 0x40000000
+jne %r0, 0x40000000, exit
 
-rsh32 r0, 19
-rsh32 r0, r7
-# r0 == 0x10
-jne r0, 0x10, exit
+rsh32 %r0, 19
+rsh32 %r0, %r7
+# %r0 == 0x10
+jne %r0, 0x10, exit
 
-xor32 r0, 0x03
-xor32 r0, r2
-# r0 == 0x11
+xor32 %r0, 0x03
+xor32 %r0, %r2
+# %r0 == 0x11
 
 exit
 -- result

--- a/tests/alu64-arith.data
+++ b/tests/alu64-arith.data
@@ -1,37 +1,37 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0
-mov r1, 1
-mov r2, 2
-mov r3, 3
-mov r4, 4
-mov r5, 5
-mov r6, 6
-mov r7, 7
-mov r8, 8
-mov r9, 9
-# r0 == 0
-jne r0, 0, exit
+mov %r0, 0
+mov %r1, 1
+mov %r2, 2
+mov %r3, 3
+mov %r4, 4
+mov %r5, 5
+mov %r6, 6
+mov %r7, 7
+mov %r8, 8
+mov %r9, 9
+# %r0 == 0
+jne %r0, 0, exit
 
-add r0, 23
-add r0, r7
-# r0 == 30
-jne r0, 30, exit
+add %r0, 23
+add %r0, %r7
+# %r0 == 30
+jne %r0, 30, exit
 
-sub r0, 13
-sub r0, r1
-# r0 == 16
-jne r0, 16, exit
+sub %r0, 13
+sub %r0, %r1
+# %r0 == 16
+jne %r0, 16, exit
 
-mul r0, 7
-mul r0, r3
-# r0 == 336
-jne r0, 336, exit
+mul %r0, 7
+mul %r0, %r3
+# %r0 == 336
+jne %r0, 336, exit
 
-div r0, 2
-div r0, r4
-# r0 == 42
+div %r0, 2
+div %r0, %r4
+# %r0 == 42
 
 exit
 -- result

--- a/tests/alu64-bit.data
+++ b/tests/alu64-bit.data
@@ -1,44 +1,44 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0
-mov r1, 1
-mov r2, 2
-mov r3, 3
-mov r4, 4
-mov r5, 5
-mov r6, 6
-mov r7, 7
-mov r8, 8
-# r0 == 0
-jne r0, 0, exit
+mov %r0, 0
+mov %r1, 1
+mov %r2, 2
+mov %r3, 3
+mov %r4, 4
+mov %r5, 5
+mov %r6, 6
+mov %r7, 7
+mov %r8, 8
+# %r0 == 0
+jne %r0, 0, exit
 
-or r0, r5
-or r0, 0xa0
-# r0 == 0xa5
-jne r0, 0xa5, exit
+or %r0, %r5
+or %r0, 0xa0
+# %r0 == 0xa5
+jne %r0, 0xa5, exit
 
-and r0, 0xa3
-mov r9, 0x91
-and r0, r9
-# r0 == 0x81
-jne r0, 0x81, exit
+and %r0, 0xa3
+mov %r9, 0x91
+and %r0, %r9
+# %r0 == 0x81
+jne %r0, 0x81, exit
 
-lsh r0, 32
-lsh r0, 22
-lsh r0, r8
-# r0 == 0x4000000000000000
+lsh %r0, 32
+lsh %r0, 22
+lsh %r0, %r8
+# %r0 == 0x4000000000000000
 # Too large to test against imm.
 
-rsh r0, 32
-rsh r0, 19
-rsh r0, r7
-# r0 == 0x10
-jne r0, 0x10, exit
+rsh %r0, 32
+rsh %r0, 19
+rsh %r0, %r7
+# %r0 == 0x10
+jne %r0, 0x10, exit
 
-xor r0, 0x03
-xor r0, r2
-# r0 == 0x11
+xor %r0, 0x03
+xor %r0, %r2
+# %r0 == 0x11
 
 exit
 -- result

--- a/tests/arsh32-high-shift.data
+++ b/tests/arsh32-high-shift.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 8
-lddw r1, 0x100000001
-arsh32 r0, r1
+mov %r0, 8
+lddw %r1, 0x100000001
+arsh32 %r0, %r1
 exit
 -- result
 0x4

--- a/tests/arsh32-imm.data
+++ b/tests/arsh32-imm.data
@@ -1,10 +1,10 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0xf8
-lsh32 r0, 28
-# r0 == 0x80000000
-arsh32 r0, 16
+mov32 %r0, 0xf8
+lsh32 %r0, 28
+# %r0 == 0x80000000
+arsh32 %r0, 16
 exit
 -- result
 0xffff8000

--- a/tests/arsh32-reg.data
+++ b/tests/arsh32-reg.data
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 -- asm
-mov32 r0, 0xf8
-mov32 r1, 16
-lsh32 r0, 28
-# r0 == 0x80000000
-arsh32 r0, r1
+mov32 %r0, 0xf8
+mov32 %r1, 16
+lsh32 %r0, 28
+# %r0 == 0x80000000
+arsh32 %r0, %r1
 exit
 -- result
 0xffff8000

--- a/tests/arsh64.data
+++ b/tests/arsh64.data
@@ -1,11 +1,11 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 1
-lsh r0, 63
-arsh r0, 55
-mov32 r1, 5
-arsh r0, r1
+mov32 %r0, 1
+lsh %r0, 63
+arsh %r0, 55
+mov32 %r1, 5
+arsh %r0, %r1
 exit
 -- result
 0xfffffffffffffff8

--- a/tests/be16-high.data
+++ b/tests/be16-high.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-ldxdw r0, [r1]
-be16 r0
+ldxdw %r0, [%r1]
+be16 %r0
 exit
 -- mem
 11 22 33 44 55 66 77 88

--- a/tests/be16.data
+++ b/tests/be16.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-ldxh r0, [r1]
-be16 r0
+ldxh %r0, [%r1]
+be16 %r0
 exit
 -- mem
 11 22

--- a/tests/be32-high.data
+++ b/tests/be32-high.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-ldxdw r0, [r1]
-be32 r0
+ldxdw %r0, [%r1]
+be32 %r0
 exit
 -- mem
 11 22 33 44 55 66 77 88

--- a/tests/be32.data
+++ b/tests/be32.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-ldxw r0, [r1]
-be32 r0
+ldxw %r0, [%r1]
+be32 %r0
 exit
 -- mem
 11 22 33 44

--- a/tests/be64.data
+++ b/tests/be64.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-ldxdw r0, [r1]
-be64 r0
+ldxdw %r0, [%r1]
+be64 %r0
 exit
 -- mem
 11 22 33 44 55 66 77 88

--- a/tests/call_local.data
+++ b/tests/call_local.data
@@ -1,45 +1,45 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-# r1-r5 are passed to the callee
-mov r0, 0
-mov r1, 1
-mov r2, 2
-mov r3, 3
-mov r4, 4
-mov r5, 5
-# r6-r9 are preserved
-mov r6, 6
-mov r7, 7
-mov r8, 8
-mov r9, 9
+# %r1-r5 are passed to the callee
+mov %r0, 0
+mov %r1, 1
+mov %r2, 2
+mov %r3, 3
+mov %r4, 4
+mov %r5, 5
+# %r6-r9 are preserved
+mov %r6, 6
+mov %r7, 7
+mov %r8, 8
+mov %r9, 9
 call local func1
-# r0 contains the return value
-# r0 should contain 1 + 2 + 3 + 4 + 5
-jne r0, 15, failed
-# r6 through r9 should be preserved
-jne r6, 6, failed
-jne r7, 7, failed
-jne r8, 8, failed
-jne r9, 9, failed
+# %r0 contains the return value
+# %r0 should contain 1 + 2 + 3 + 4 + 5
+jne %r0, 15, failed
+# %r6 through %r9 should be preserved
+jne %r6, 6, failed
+jne %r7, 7, failed
+jne %r8, 8, failed
+jne %r9, 9, failed
 # Success
-mov r0, 1
+mov %r0, 1
 exit
 failed:
-mov r0, -1
+mov %r0, -1
 exit
-# Function sets r0 = r1 + r2 + r3 + r4 + r5
+# Function sets %r0 = %r1 + %r2 + %r3 + %r4 + %r5
 func1:
-mov r0, 0
-add r0, r1
-add r0, r2
-add r0, r3
-add r0, r4
-add r0, r5
-mov r6, 0
-mov r7, 0
-mov r8, 0
-mov r9, 0
+mov %r0, 0
+add %r0, %r1
+add %r0, %r2
+add %r0, %r3
+add %r0, %r4
+add %r0, %r5
+mov %r6, 0
+mov %r7, 0
+mov %r8, 0
+mov %r9, 0
 exit
 -- result
 0x1

--- a/tests/call_unwind_fail.data
+++ b/tests/call_unwind_fail.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r1, -1
+mov %r1, -1
 call 5
-mov r0, 2
+mov %r0, 2
 exit
 -- result
 0x2

--- a/tests/div-by-zero-reg.data
+++ b/tests/div-by-zero-reg.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 1
-mov32 r1, 0
-div32 r0, r1
+mov32 %r0, 1
+mov32 %r1, 0
+div32 %r0, %r1
 exit
 -- result
 0x0

--- a/tests/div32-high-divisor.data
+++ b/tests/div32-high-divisor.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 12
-lddw r1, 0x100000004
-div32 r0, r1
+mov %r0, 12
+lddw %r1, 0x100000004
+div32 %r0, %r1
 exit
 -- result
 0x3

--- a/tests/div32-imm.data
+++ b/tests/div32-imm.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-lddw r0, 0x10000000c
-div32 r0, 4
+lddw %r0, 0x10000000c
+div32 %r0, 4
 exit
 -- result
 0x3

--- a/tests/div32-reg.data
+++ b/tests/div32-reg.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-lddw r0, 0x10000000c
-mov r1, 4
-div32 r0, r1
+lddw %r0, 0x10000000c
+mov %r1, 4
+div32 %r0, %r1
 exit
 -- result
 0x3

--- a/tests/div64-by-zero-reg.data
+++ b/tests/div64-by-zero-reg.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 1
-mov32 r1, 0
-div r0, r1
+mov32 %r0, 1
+mov32 %r1, 0
+div %r0, %r1
 exit
 -- result
 0x0

--- a/tests/div64-imm.data
+++ b/tests/div64-imm.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0xc
-lsh r0, 32
-div r0, 4
+mov %r0, 0xc
+lsh %r0, 32
+div %r0, 4
 exit
 -- result
 0x300000000

--- a/tests/div64-negative-imm.data
+++ b/tests/div64-negative-imm.data
@@ -1,8 +1,8 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0xFFFFFFFFFFFFFFFF
-div r0, -10
+lddw %r0, 0xFFFFFFFFFFFFFFFF
+div %r0, -10
 exit
 -- result
 0x1

--- a/tests/div64-negative-reg.data
+++ b/tests/div64-negative-reg.data
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0xFFFFFFFFFFFFFFFF
-mov32 r1, -10
-div r0, r1
+lddw %r0, 0xFFFFFFFFFFFFFFFF
+mov32 %r1, -10
+div %r0, %r1
 exit
 -- result
 0x10000000A

--- a/tests/div64-reg.data
+++ b/tests/div64-reg.data
@@ -1,10 +1,10 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0xc
-lsh r0, 32
-mov r1, 4
-div r0, r1
+mov %r0, 0xc
+lsh %r0, 32
+mov %r1, 4
+div %r0, %r1
 exit
 -- result
 0x300000000

--- a/tests/exit-not-last.data
+++ b/tests/exit-not-last.data
@@ -1,13 +1,13 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r1, 0
+mov %r1, 0
 ja L2
 L1:
-mov r2, 0
+mov %r2, 0
 exit
 L2:
-mov r0, 0
+mov %r0, 0
 ja L1
 -- result
 0x0

--- a/tests/exit.data
+++ b/tests/exit.data
@@ -1,7 +1,7 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0
+mov %r0, 0
 exit
 -- result
 0x0

--- a/tests/jeq-imm.data
+++ b/tests/jeq-imm.data
@@ -1,15 +1,15 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov32 r1, 0xa
-jeq r1, 0xb, exit # Not taken
+mov32 %r0, 0
+mov32 %r1, 0xa
+jeq %r1, 0xb, exit # Not taken
 
-mov32 r0, 1
-mov32 r1, 0xb
-jeq r1, 0xb, exit # Taken
+mov32 %r0, 1
+mov32 %r1, 0xb
+jeq %r1, 0xb, exit # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 exit
 -- result
 0x1

--- a/tests/jeq-reg.data
+++ b/tests/jeq-reg.data
@@ -1,16 +1,16 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov32 r1, 0xa
-mov32 r2, 0xb
-jeq r1, r2, exit # Not taken
+mov32 %r0, 0
+mov32 %r1, 0xa
+mov32 %r2, 0xb
+jeq %r1, %r2, exit # Not taken
 
-mov32 r0, 1
-mov32 r1, 0xb
-jeq r1, r2, exit # Taken
+mov32 %r0, 1
+mov32 %r1, 0xb
+jeq %r1, %r2, exit # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 exit
 -- result
 0x1

--- a/tests/jeq32-imm.data
+++ b/tests/jeq32-imm.data
@@ -1,21 +1,21 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0x0
-mov32 r1, 0xa
-jeq32 r1, 0xb, exit # Not taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0x0
+mov32 %r1, 0xa
+jeq32 %r1, 0xb, exit # Not taken
 
-mov32 r0, 1
+mov32 %r0, 1
 # Confirm upper bits are ignored in comparison
-mov r1, 0xb
-# set r1 to 0x10000000b
-or r1, r9
-jeq32 r1, 0xb, exit # Taken
+mov %r1, 0xb
+# set %r1 to 0x10000000b
+or %r1, %r9
+jeq32 %r1, 0xb, exit # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 exit
 -- result
 0x1

--- a/tests/jeq32-reg.data
+++ b/tests/jeq32-reg.data
@@ -1,21 +1,21 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0xa
-mov32 r2, 0xb
-jeq32 r1, r2, exit # Not taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0xa
+mov32 %r2, 0xb
+jeq32 %r1, %r2, exit # Not taken
 
-mov32 r0, 1
-mov32 r1, 0xb
-# set r1 to 0x10000000b
-or r1, r9
-jeq32 r1, r2, exit # Taken
+mov32 %r0, 1
+mov32 %r1, 0xb
+# set %r1 to 0x10000000b
+or %r1, %r9
+jeq32 %r1, %r2, exit # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 exit
 -- result
 0x1

--- a/tests/jge-imm.data
+++ b/tests/jge-imm.data
@@ -1,15 +1,15 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov32 r1, 0xa
-jge r1, 0xb, exit # Not taken
+mov32 %r0, 0
+mov32 %r1, 0xa
+jge %r1, 0xb, exit # Not taken
 
-mov32 r0, 1
-mov32 r1, 0xc
-jge r1, 0xb, exit # Taken
+mov32 %r0, 1
+mov32 %r1, 0xc
+jge %r1, 0xb, exit # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 exit
 -- result
 0x1

--- a/tests/jge32-imm.data
+++ b/tests/jge32-imm.data
@@ -1,20 +1,20 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0xa
-jge32 r1, 0xb, exit # Not taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0xa
+jge32 %r1, 0xb, exit # Not taken
 
-mov32 r0, 1
-# set r1 to 0x10000000c
-mov32 r1, 0xc
-or r1, r9
-jge32 r1, 0xb, exit # Taken
+mov32 %r0, 1
+# set %r1 to 0x10000000c
+mov32 %r1, 0xc
+or %r1, %r9
+jge32 %r1, 0xb, exit # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 
 exit
 -- result

--- a/tests/jge32-reg.data
+++ b/tests/jge32-reg.data
@@ -1,21 +1,21 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0xa
-mov32 r2, 0xb
-jge32 r1, r2, exit # Not taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0xa
+mov32 %r2, 0xb
+jge32 %r1, %r2, exit # Not taken
 
-mov32 r0, 1
-# set r1 to 0x10000000c
-mov32 r1, 0xc
-or r1, r9
-jge32 r1, r2, exit # Taken
+mov32 %r0, 1
+# set %r1 to 0x10000000c
+mov32 %r1, 0xc
+or %r1, %r9
+jge32 %r1, %r2, exit # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 
 exit
 -- result

--- a/tests/jgt-imm.data
+++ b/tests/jgt-imm.data
@@ -1,14 +1,14 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov32 r1, 5
-jgt r1, 6, exit # Not taken
-jgt r1, 5, exit # Not taken
-jgt r1, 4, L1 # Taken
+mov32 %r0, 0
+mov32 %r1, 5
+jgt %r1, 6, exit # Not taken
+jgt %r1, 5, exit # Not taken
+jgt %r1, 4, L1 # Taken
 exit
 L1:
-mov32 r0, 1
+mov32 %r0, 1
 exit
 -- result
 0x1

--- a/tests/jgt-reg.data
+++ b/tests/jgt-reg.data
@@ -1,16 +1,16 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0
-mov r1, 5
-mov r2, 6
-mov r3, 4
-jgt r1, r2, exit # Not taken
-jgt r1, r1, exit # Not taken
-jgt r1, r3, taken # Taken
+mov %r0, 0
+mov %r1, 5
+mov %r2, 6
+mov %r3, 4
+jgt %r1, %r2, exit # Not taken
+jgt %r1, %r1, exit # Not taken
+jgt %r1, %r3, taken # Taken
 exit
 taken:
-mov r0, 1
+mov %r0, 1
 exit
 -- result
 0x1

--- a/tests/jgt32-imm.data
+++ b/tests/jgt32-imm.data
@@ -1,19 +1,19 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-# set r1 to 0x100000005
-mov32 r1, 5
-or r1, r9
-jgt32 r1, 6, exit # Not taken
-jgt32 r1, 5, exit # Not taken
-jgt32 r1, 4, taken # Taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+# set %r1 to 0x100000005
+mov32 %r1, 5
+or %r1, %r9
+jgt32 %r1, 6, exit # Not taken
+jgt32 %r1, 5, exit # Not taken
+jgt32 %r1, 4, taken # Taken
 exit
 taken:
-mov32 r0, 1
+mov32 %r0, 1
 exit
 -- result
 0x1

--- a/tests/jgt32-reg.data
+++ b/tests/jgt32-reg.data
@@ -1,22 +1,22 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov r0, 0
-mov r1, 5
-mov32 r1, 5
-# set r1 to 0x100000005
-or r1, r9
-mov r2, 6
-mov r3, 4
-jgt32 r1, r2, exit # Not taken
-jgt32 r1, r1, exit # Not taken
-jgt32 r1, r3, taken # Taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov %r0, 0
+mov %r1, 5
+mov32 %r1, 5
+# set %r1 to 0x100000005
+or %r1, %r9
+mov %r2, 6
+mov %r3, 4
+jgt32 %r1, %r2, exit # Not taken
+jgt32 %r1, %r1, exit # Not taken
+jgt32 %r1, %r3, taken # Taken
 exit
 taken:
-mov r0, 1
+mov %r0, 1
 exit
 -- result
 0x1

--- a/tests/jit-bounce.data
+++ b/tests/jit-bounce.data
@@ -1,13 +1,13 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 1
-mov r6, r0
-mov r7, r6
-mov r8, r7
-mov r9, r8
-# TODO r10
-mov r0, r9
+mov %r0, 1
+mov %r6, %r0
+mov %r7, %r6
+mov %r8, %r7
+mov %r9, %r8
+# TODO %r10
+mov %r0, %r9
 exit
 -- result
 0x1

--- a/tests/jle-imm.data
+++ b/tests/jle-imm.data
@@ -1,16 +1,16 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov32 r1, 5
-jle r1, 4, exit # Not taken
-jle r1, 6, +1 # Taken
+mov32 %r0, 0
+mov32 %r1, 5
+jle %r1, 4, exit # Not taken
+jle %r1, 6, +1 # Taken
 exit
 taken:
-jle r1, 5, +1 # Taken
+jle %r1, 5, +1 # Taken
 exit
 taken2:
-mov32 r0, 1
+mov32 %r0, 1
 exit
 -- result
 0x1

--- a/tests/jle-reg.data
+++ b/tests/jle-reg.data
@@ -1,16 +1,16 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0
-mov r1, 5
-mov r2, 4
-mov r3, 6
-jle r1, r2, exit # Not taken
-jle r1, r1, +1 # Taken
+mov %r0, 0
+mov %r1, 5
+mov %r2, 4
+mov %r3, 6
+jle %r1, %r2, exit # Not taken
+jle %r1, %r1, +1 # Taken
 exit
-jle r1, r3, +1 # Taken
+jle %r1, %r3, +1 # Taken
 exit
-mov r0, 1
+mov %r0, 1
 exit
 -- result
 0x1

--- a/tests/jle32-imm.data
+++ b/tests/jle32-imm.data
@@ -1,19 +1,19 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 5
-# set r1 to 0x100000005
-or r1, r9
-jle32 r1, 4, exit # Not taken
-jle32 r1, 6, +1 # Taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 5
+# set %r1 to 0x100000005
+or %r1, %r9
+jle32 %r1, 4, exit # Not taken
+jle32 %r1, 6, +1 # Taken
 exit
-jle32 r1, 5, +1 # Taken
+jle32 %r1, 5, +1 # Taken
 exit
-mov32 r0, 1
+mov32 %r0, 1
 exit
 -- result
 0x1

--- a/tests/jle32-reg.data
+++ b/tests/jle32-reg.data
@@ -1,21 +1,21 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov r0, 0
-mov r1, 5
-mov r2, 4
-mov r3, 6
-# set r1 to 0x100000005
-or r1, r9
-jle32 r1, r2, exit # Not taken
-jle32 r1, r1, +1 # Taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov %r0, 0
+mov %r1, 5
+mov %r2, 4
+mov %r3, 6
+# set %r1 to 0x100000005
+or %r1, %r9
+jle32 %r1, %r2, exit # Not taken
+jle32 %r1, %r1, +1 # Taken
 exit
-jle32 r1, r3, +1 # Taken
+jle32 %r1, %r3, +1 # Taken
 exit
-mov r0, 1
+mov %r0, 1
 exit
 -- result
 0x1

--- a/tests/jlt-imm.data
+++ b/tests/jlt-imm.data
@@ -1,13 +1,13 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov32 r1, 5
-jlt r1, 4, exit # Not taken
-jlt r1, 5, exit # Not taken
-jlt r1, 6, +1 # Taken
+mov32 %r0, 0
+mov32 %r1, 5
+jlt %r1, 4, exit # Not taken
+jlt %r1, 5, exit # Not taken
+jlt %r1, 6, +1 # Taken
 exit
-mov32 r0, 1
+mov32 %r0, 1
 exit
 -- result
 0x1

--- a/tests/jlt-reg.data
+++ b/tests/jlt-reg.data
@@ -1,15 +1,15 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0
-mov r1, 5
-mov r2, 4
-mov r3, 6
-jlt r1, r2, exit # Not taken
-jlt r1, r1, exit # Not taken
-jlt r1, r3, +1 # Taken
+mov %r0, 0
+mov %r1, 5
+mov %r2, 4
+mov %r3, 6
+jlt %r1, %r2, exit # Not taken
+jlt %r1, %r1, exit # Not taken
+jlt %r1, %r3, +1 # Taken
 exit
-mov r0, 1
+mov %r0, 1
 exit
 -- result
 0x1

--- a/tests/jlt32-imm.data
+++ b/tests/jlt32-imm.data
@@ -1,18 +1,18 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 5
-# set r1 to 0x100000005
-or r1, r9
-jlt32 r1, 4, exit # Not taken
-jlt32 r1, 5, exit # Not taken
-jlt32 r1, 6, +1 # Taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 5
+# set %r1 to 0x100000005
+or %r1, %r9
+jlt32 %r1, 4, exit # Not taken
+jlt32 %r1, 5, exit # Not taken
+jlt32 %r1, 6, +1 # Taken
 exit
-mov32 r0, 1
+mov32 %r0, 1
 exit
 -- result
 0x1

--- a/tests/jlt32-reg.data
+++ b/tests/jlt32-reg.data
@@ -1,20 +1,20 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov r0, 0
-mov r1, 5
-mov r2, 4
-mov r3, 6
-# set r1 to 0x100000005
-or r1, r9
-jlt32 r1, r2, exit # Not taken
-jlt32 r1, r1, exit # Not taken
-jlt32 r1, r3, +1 # Taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov %r0, 0
+mov %r1, 5
+mov %r2, 4
+mov %r3, 6
+# set %r1 to 0x100000005
+or %r1, %r9
+jlt32 %r1, %r2, exit # Not taken
+jlt32 %r1, %r1, exit # Not taken
+jlt32 %r1, %r3, +1 # Taken
 exit
-mov r0, 1
+mov %r0, 1
 exit
 -- result
 0x1

--- a/tests/jne-reg.data
+++ b/tests/jne-reg.data
@@ -1,16 +1,16 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov32 r1, 0xb
-mov32 r2, 0xb
-jne r1, r2, exit # Not taken
+mov32 %r0, 0
+mov32 %r1, 0xb
+mov32 %r2, 0xb
+jne %r1, %r2, exit # Not taken
 
-mov32 r0, 1
-mov32 r1, 0xa
-jne r1, r2, +1 # Taken
+mov32 %r0, 1
+mov32 %r1, 0xa
+jne %r1, %r2, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 exit
 -- result
 0x1

--- a/tests/jne32-imm.data
+++ b/tests/jne32-imm.data
@@ -1,22 +1,22 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0xb
-# set r1 to 0x10000000b
-or r1, r9
-jne32 r1, 0xb, +4 # Not taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0xb
+# set %r1 to 0x10000000b
+or %r1, %r9
+jne32 %r1, 0xb, +4 # Not taken
 
-mov32 r0, 1
-mov32 r1, 0xa
-# set r1 to 0x10000000a
-or r1, r9
-jne32 r1, 0xb, +1 # Taken
+mov32 %r0, 1
+mov32 %r1, 0xa
+# set %r1 to 0x10000000a
+or %r1, %r9
+jne32 %r1, 0xb, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 exit
 -- result
 0x1

--- a/tests/jne32-reg.data
+++ b/tests/jne32-reg.data
@@ -1,23 +1,23 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0xb
-# set r1 to 0x10000000b
-or r1, r9
-mov32 r2, 0xb
-jne32 r1, r2, +4 # Not taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0xb
+# set %r1 to 0x10000000b
+or %r1, %r9
+mov32 %r2, 0xb
+jne32 %r1, %r2, +4 # Not taken
 
-mov32 r0, 1
-mov32 r1, 0xa
-# set r1 to 0x10000000a
-or r1, r9
-jne32 r1, r2, +1 # Taken
+mov32 %r0, 1
+mov32 %r1, 0xa
+# set %r1 to 0x10000000a
+or %r1, %r9
+jne32 %r1, %r2, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 exit
 -- result
 0x1

--- a/tests/jset-imm.data
+++ b/tests/jset-imm.data
@@ -1,15 +1,15 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov32 r1, 0x7
-jset r1, 0x8, exit # Not taken
+mov32 %r0, 0
+mov32 %r1, 0x7
+jset %r1, 0x8, exit # Not taken
 
-mov32 r0, 1
-mov32 r1, 0x9
-jset r1, 0x8, +1 # Taken
+mov32 %r0, 1
+mov32 %r1, 0x9
+jset %r1, 0x8, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 
 exit
 -- result

--- a/tests/jset-reg.data
+++ b/tests/jset-reg.data
@@ -1,16 +1,16 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov32 r1, 0x7
-mov32 r2, 0x8
-jset r1, r2, exit # Not taken
+mov32 %r0, 0
+mov32 %r1, 0x7
+mov32 %r2, 0x8
+jset %r1, %r2, exit # Not taken
 
-mov32 r0, 1
-mov32 r1, 0x9
-jset r1, r2, +1 # Taken
+mov32 %r0, 1
+mov32 %r1, 0x9
+jset %r1, %r2, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 
 exit
 -- result

--- a/tests/jset32-imm.data
+++ b/tests/jset32-imm.data
@@ -1,20 +1,20 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0x7
-# set r1 to 0x100000007
-or r1, r9
-jset32 r1, 0x8, exit # Not taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0x7
+# set %r1 to 0x100000007
+or %r1, %r9
+jset32 %r1, 0x8, exit # Not taken
 
-mov32 r0, 1
-mov32 r1, 0x9
-jset32 r1, 0x8, +1 # Taken
+mov32 %r0, 1
+mov32 %r1, 0x9
+jset32 %r1, 0x8, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 
 exit
 -- result

--- a/tests/jset32-reg.data
+++ b/tests/jset32-reg.data
@@ -1,21 +1,21 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0x7
-# set r1 to 0x100000007
-or r1, r9
-mov32 r2, 0x8
-jset32 r1, r2, exit # Not taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0x7
+# set %r1 to 0x100000007
+or %r1, %r9
+mov32 %r2, 0x8
+jset32 %r1, %r2, exit # Not taken
 
-mov32 r0, 1
-mov32 r1, 0x9
-jset32 r1, r2, +1 # Taken
+mov32 %r0, 1
+mov32 %r1, 0x9
+jset32 %r1, %r2, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 
 exit
 -- result

--- a/tests/jsge-imm.data
+++ b/tests/jsge-imm.data
@@ -1,16 +1,16 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov r1, 0xfffffffe
-jsge r1, 0xffffffff, exit # Not taken
-jsge r1, 0, +4 # Not taken
+mov32 %r0, 0
+mov %r1, 0xfffffffe
+jsge %r1, 0xffffffff, exit # Not taken
+jsge %r1, 0, +4 # Not taken
 
-mov32 r0, 1
-mov r1, 0xffffffff
-jsge r1, 0xffffffff, +1 # Taken
+mov32 %r0, 1
+mov %r1, 0xffffffff
+jsge %r1, 0xffffffff, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 
 exit
 -- result

--- a/tests/jsge-reg.data
+++ b/tests/jsge-reg.data
@@ -1,18 +1,18 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov r1, 0xfffffffe
-mov r2, 0xffffffff
-mov32 r3, 0
-jsge r1, r2, exit # Not taken
-jsge r1, r3, exit # Not taken
+mov32 %r0, 0
+mov %r1, 0xfffffffe
+mov %r2, 0xffffffff
+mov32 %r3, 0
+jsge %r1, %r2, exit # Not taken
+jsge %r1, %r3, exit # Not taken
 
-mov32 r0, 1
-mov r1, r2
-jsge r1, r2, +1 # Taken
+mov32 %r0, 1
+mov %r1, %r2
+jsge %r1, %r2, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 
 exit
 -- result

--- a/tests/jsge32-imm.data
+++ b/tests/jsge32-imm.data
@@ -1,21 +1,21 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0xfffffffe
-# set r1 to 0x1fffffffe
-or r1, r9
-jsge32 r1, 0xffffffff, exit # Not taken
-jsge32 r1, 0, exit # Not taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0xfffffffe
+# set %r1 to 0x1fffffffe
+or %r1, %r9
+jsge32 %r1, 0xffffffff, exit # Not taken
+jsge32 %r1, 0, exit # Not taken
 
-mov32 r0, 1
-mov r1, 0xffffffff
-jsge32 r1, 0xffffffff, +1 # Taken
+mov32 %r0, 1
+mov %r1, 0xffffffff
+jsge32 %r1, 0xffffffff, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 
 exit
 -- result

--- a/tests/jsge32-reg.data
+++ b/tests/jsge32-reg.data
@@ -1,23 +1,23 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0xfffffffe
-# set r1 to 0x1fffffffe
-or r1, r9
-mov r2, 0xffffffff
-mov32 r3, 0
-jsge32 r1, r2, exit # Not taken
-jsge32 r1, r3, exit # Not taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0xfffffffe
+# set %r1 to 0x1fffffffe
+or %r1, %r9
+mov %r2, 0xffffffff
+mov32 %r3, 0
+jsge32 %r1, %r2, exit # Not taken
+jsge32 %r1, %r3, exit # Not taken
 
-mov32 r0, 1
-mov r1, r2
-jsge32 r1, r2, +1 # Taken
+mov32 %r0, 1
+mov %r1, %r2
+jsge32 %r1, %r2, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 
 exit
 -- result

--- a/tests/jsgt-imm.data
+++ b/tests/jsgt-imm.data
@@ -1,15 +1,15 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov r1, 0xfffffffe
-jsgt r1, 0xffffffff, exit # Not taken
+mov32 %r0, 0
+mov %r1, 0xfffffffe
+jsgt %r1, 0xffffffff, exit # Not taken
 
-mov32 r0, 1
-mov32 r1, 0
-jsgt r1, 0xffffffff, +1 # Taken
+mov32 %r0, 1
+mov32 %r1, 0
+jsgt %r1, 0xffffffff, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 
 exit
 -- result

--- a/tests/jsgt-reg.data
+++ b/tests/jsgt-reg.data
@@ -1,16 +1,16 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov r1, 0xfffffffe
-mov r2, 0xffffffff
-jsgt r1, r2, exit # Not taken
+mov32 %r0, 0
+mov %r1, 0xfffffffe
+mov %r2, 0xffffffff
+jsgt %r1, %r2, exit # Not taken
 
-mov32 r0, 1
-mov32 r1, 0
-jsgt r1, r2, +1 # Taken
+mov32 %r0, 1
+mov32 %r1, 0
+jsgt %r1, %r2, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 
 exit
 -- result

--- a/tests/jsgt32-imm.data
+++ b/tests/jsgt32-imm.data
@@ -1,20 +1,20 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0xfffffffe
-# set r1 to 0x1fffffffe
-or r1, r9
-jsgt32 r1, 0xffffffff, exit # Not taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0xfffffffe
+# set %r1 to 0x1fffffffe
+or %r1, %r9
+jsgt32 %r1, 0xffffffff, exit # Not taken
 
-mov32 r0, 1
-mov32 r1, 0
-jsgt32 r1, 0xffffffff, +1 # Taken
+mov32 %r0, 1
+mov32 %r1, 0
+jsgt32 %r1, 0xffffffff, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 
 exit
 -- result

--- a/tests/jsgt32-reg.data
+++ b/tests/jsgt32-reg.data
@@ -1,21 +1,21 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0xfffffffe
-# set r1 to 0x1fffffffe
-or r1, r9
-mov r2, 0xffffffff
-jsgt32 r1, r2, exit # Not taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0xfffffffe
+# set %r1 to 0x1fffffffe
+or %r1, %r9
+mov %r2, 0xffffffff
+jsgt32 %r1, %r2, exit # Not taken
 
-mov32 r0, 1
-mov32 r1, 0
-jsgt32 r1, r2, +1 # Taken
+mov32 %r0, 1
+mov32 %r1, 0
+jsgt32 %r1, %r2, +1 # Taken
 
-mov32 r0, 2 # Skipped
+mov32 %r0, 2 # Skipped
 
 exit
 -- result

--- a/tests/jsle-imm.data
+++ b/tests/jsle-imm.data
@@ -1,14 +1,14 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov r1, 0xfffffffe
-jsle r1, 0xfffffffd, exit # Not taken
-jsle r1, 0xffffffff, +1 # Taken
+mov32 %r0, 0
+mov %r1, 0xfffffffe
+jsle %r1, 0xfffffffd, exit # Not taken
+jsle %r1, 0xffffffff, +1 # Taken
 exit
-mov32 r0, 1
-jsle r1, 0xfffffffe, +1 # Taken
-mov32 r0, 2
+mov32 %r0, 1
+jsle %r1, 0xfffffffe, +1 # Taken
+mov32 %r0, 2
 exit
 -- result
 0x1

--- a/tests/jsle-reg.data
+++ b/tests/jsle-reg.data
@@ -1,17 +1,17 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov r1, 0xffffffff
-mov r2, 0xfffffffe
-mov32 r3, 0
-jsle r1, r2, exit # Not taken
-jsle r1, r3, +1 # Taken
+mov32 %r0, 0
+mov %r1, 0xffffffff
+mov %r2, 0xfffffffe
+mov32 %r3, 0
+jsle %r1, %r2, exit # Not taken
+jsle %r1, %r3, +1 # Taken
 exit
-mov32 r0, 1
-mov r1, r2
-jsle r1, r2, +1 # Taken
-mov32 r0, 2
+mov32 %r0, 1
+mov %r1, %r2
+jsle %r1, %r2, +1 # Taken
+mov32 %r0, 2
 exit
 -- result
 0x1

--- a/tests/jsle32-imm.data
+++ b/tests/jsle32-imm.data
@@ -1,19 +1,19 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0xfffffffe
-# set r1 to 0x1fffffffe
-or r1, r9
-jsle32 r1, 0xfffffffd, exit # Not taken
-jsle32 r1, 0xffffffff, +1 # Taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0xfffffffe
+# set %r1 to 0x1fffffffe
+or %r1, %r9
+jsle32 %r1, 0xfffffffd, exit # Not taken
+jsle32 %r1, 0xffffffff, +1 # Taken
 exit
-mov32 r0, 1
-jsle32 r1, 0xfffffffe, +1 # Taken
-mov32 r0, 2
+mov32 %r0, 1
+jsle32 %r1, 0xfffffffe, +1 # Taken
+mov32 %r0, 2
 exit
 -- result
 0x1

--- a/tests/jsle32-reg.data
+++ b/tests/jsle32-reg.data
@@ -1,22 +1,22 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0xffffffff
-# set r1 to 0x1ffffffff
-or r1, r9
-mov r2, 0xfffffffe
-mov32 r3, 0
-jsle32 r1, r2, exit # Not taken
-jsle32 r1, r3, +1 # Taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0xffffffff
+# set %r1 to 0x1ffffffff
+or %r1, %r9
+mov %r2, 0xfffffffe
+mov32 %r3, 0
+jsle32 %r1, %r2, exit # Not taken
+jsle32 %r1, %r3, +1 # Taken
 exit
-mov32 r0, 1
-mov r1, r2
-jsle32 r1, r2, +1 # Taken
-mov32 r0, 2
+mov32 %r0, 1
+mov %r1, %r2
+jsle32 %r1, %r2, +1 # Taken
+mov32 %r0, 2
 exit
 -- result
 0x1

--- a/tests/jslt-imm.data
+++ b/tests/jslt-imm.data
@@ -1,13 +1,13 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov r1, 0xfffffffe
-jslt r1, 0xfffffffd, exit # Not taken
-jslt r1, 0xfffffffe, exit # Not taken
-jslt r1, 0xffffffff, +1 # Taken
+mov32 %r0, 0
+mov %r1, 0xfffffffe
+jslt %r1, 0xfffffffd, exit # Not taken
+jslt %r1, 0xfffffffe, exit # Not taken
+jslt %r1, 0xffffffff, +1 # Taken
 exit
-mov32 r0, 1
+mov32 %r0, 1
 exit
 -- result
 0x1

--- a/tests/jslt-reg.data
+++ b/tests/jslt-reg.data
@@ -1,15 +1,15 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0
-mov r1, 0xfffffffe
-mov r2, 0xfffffffd
-mov r3, 0xffffffff
-jslt r1, r1, exit # Not taken
-jslt r1, r2, exit # Not taken
-jslt r1, r3, +1 # Taken
+mov32 %r0, 0
+mov %r1, 0xfffffffe
+mov %r2, 0xfffffffd
+mov %r3, 0xffffffff
+jslt %r1, %r1, exit # Not taken
+jslt %r1, %r2, exit # Not taken
+jslt %r1, %r3, +1 # Taken
 exit
-mov32 r0, 1
+mov32 %r0, 1
 exit
 -- result
 0x1

--- a/tests/jslt32-imm.data
+++ b/tests/jslt32-imm.data
@@ -1,18 +1,18 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0xfffffffe
-# set r1 to 0x1fffffffe
-or r1, r9
-jslt32 r1, 0xfffffffd, exit # Not taken
-jslt32 r1, 0xfffffffe, exit # Not taken
-jslt32 r1, 0xffffffff, +1 # Taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0xfffffffe
+# set %r1 to 0x1fffffffe
+or %r1, %r9
+jslt32 %r1, 0xfffffffd, exit # Not taken
+jslt32 %r1, 0xfffffffe, exit # Not taken
+jslt32 %r1, 0xffffffff, +1 # Taken
 exit
-mov32 r0, 1
+mov32 %r0, 1
 exit
 -- result
 0x1

--- a/tests/jslt32-reg.data
+++ b/tests/jslt32-reg.data
@@ -1,20 +1,20 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set r9 to 0x100000000
-mov r9, 1
-lsh r9, 32
-mov32 r0, 0
-mov32 r1, 0xfffffffe
-# set r1 to 0x1fffffffe
-or r1, r9
-mov r2, 0xfffffffd
-mov r3, 0xffffffff
-jslt32 r1, r1, exit # Not taken
-jslt32 r1, r2, exit # Not taken
-jslt32 r1, r3, +1 # Taken
+# Set %r9 to 0x100000000
+mov %r9, 1
+lsh %r9, 32
+mov32 %r0, 0
+mov32 %r1, 0xfffffffe
+# set %r1 to 0x1fffffffe
+or %r1, %r9
+mov %r2, 0xfffffffd
+mov %r3, 0xffffffff
+jslt32 %r1, %r1, exit # Not taken
+jslt32 %r1, %r2, exit # Not taken
+jslt32 %r1, %r3, +1 # Taken
 exit
-mov32 r0, 1
+mov32 %r0, 1
 exit
 -- result
 0x1

--- a/tests/lddw.data
+++ b/tests/lddw.data
@@ -1,7 +1,7 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-lddw r0, 0x1122334455667788
+lddw %r0, 0x1122334455667788
 exit
 -- raw
 0x5566778800000018

--- a/tests/lddw2.data
+++ b/tests/lddw2.data
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 -- asm
 # Test decimal 64bit immediate value.
-lddw r0, 2147483648
+lddw %r0, 2147483648
 exit
 -- result
 0x0000000080000000

--- a/tests/ldxb-all.data
+++ b/tests/ldxb-all.data
@@ -1,47 +1,47 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, r1
+mov %r0, %r1
 
-ldxb r9, [r0+0]
-lsh r9, 0
+ldxb %r9, [%r0+0]
+lsh %r9, 0
 
-ldxb r8, [r0+0x1]
-lsh r8, 4
+ldxb %r8, [%r0+0x1]
+lsh %r8, 4
 
-ldxb r7, [r0+2]
-lsh r7, 8
+ldxb %r7, [%r0+2]
+lsh %r7, 8
 
-ldxb r6, [r0+3]
-lsh r6, 12
+ldxb %r6, [%r0+3]
+lsh %r6, 12
 
-ldxb r5, [r0+4]
-lsh r5, 16
+ldxb %r5, [%r0+4]
+lsh %r5, 16
 
-ldxb r4, [r0+5]
-lsh r4, 20
+ldxb %r4, [%r0+5]
+lsh %r4, 20
 
-ldxb r3, [r0+6]
-lsh r3, 24
+ldxb %r3, [%r0+6]
+lsh %r3, 24
 
-ldxb r2, [r0+7]
-lsh r2, 28
+ldxb %r2, [%r0+7]
+lsh %r2, 28
 
-ldxb r1, [r0+8]
-lsh r1, 32
+ldxb %r1, [%r0+8]
+lsh %r1, 32
 
-ldxb r0, [r0+9]
-lsh r0, 36
+ldxb %r0, [%r0+9]
+lsh %r0, 36
 
-or r0, r1
-or r0, r2
-or r0, r3
-or r0, r4
-or r0, r5
-or r0, r6
-or r0, r7
-or r0, r8
-or r0, r9
+or %r0, %r1
+or %r0, %r2
+or %r0, %r3
+or %r0, %r4
+or %r0, %r5
+or %r0, %r6
+or %r0, %r7
+or %r0, %r8
+or %r0, %r9
 
 exit
 -- result

--- a/tests/ldxb.data
+++ b/tests/ldxb.data
@@ -1,7 +1,7 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-ldxb r0, [r1+0x2]
+ldxb %r0, [%r1+0x2]
 exit
 -- mem
 aa bb 11 cc dd

--- a/tests/ldxdw.data
+++ b/tests/ldxdw.data
@@ -1,7 +1,7 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-ldxdw r0, [r1+2]
+ldxdw %r0, [%r1+2]
 exit
 -- mem
 aa bb 11 22 33 44 55 66 77 88 cc dd

--- a/tests/ldxh-all.data
+++ b/tests/ldxh-all.data
@@ -1,57 +1,57 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, r1
+mov %r0, %r1
 
-ldxh r9, [r0+0]
-be16 r9
-lsh r9, 0
+ldxh %r9, [%r0+0]
+be16 %r9
+lsh %r9, 0
 
-ldxh r8, [r0+2]
-be16 r8
-lsh r8, 4
+ldxh %r8, [%r0+2]
+be16 %r8
+lsh %r8, 4
 
-ldxh r7, [r0+4]
-be16 r7
-lsh r7, 8
+ldxh %r7, [%r0+4]
+be16 %r7
+lsh %r7, 8
 
-ldxh r6, [r0+6]
-be16 r6
-lsh r6, 12
+ldxh %r6, [%r0+6]
+be16 %r6
+lsh %r6, 12
 
-ldxh r5, [r0+8]
-be16 r5
-lsh r5, 16
+ldxh %r5, [%r0+8]
+be16 %r5
+lsh %r5, 16
 
-ldxh r4, [r0+10]
-be16 r4
-lsh r4, 20
+ldxh %r4, [%r0+10]
+be16 %r4
+lsh %r4, 20
 
-ldxh r3, [r0+12]
-be16 r3
-lsh r3, 24
+ldxh %r3, [%r0+12]
+be16 %r3
+lsh %r3, 24
 
-ldxh r2, [r0+14]
-be16 r2
-lsh r2, 28
+ldxh %r2, [%r0+14]
+be16 %r2
+lsh %r2, 28
 
-ldxh r1, [r0+16]
-be16 r1
-lsh r1, 32
+ldxh %r1, [%r0+16]
+be16 %r1
+lsh %r1, 32
 
-ldxh r0, [r0+18]
-be16 r0
-lsh r0, 36
+ldxh %r0, [%r0+18]
+be16 %r0
+lsh %r0, 36
 
-or r0, r1
-or r0, r2
-or r0, r3
-or r0, r4
-or r0, r5
-or r0, r6
-or r0, r7
-or r0, r8
-or r0, r9
+or %r0, %r1
+or %r0, %r2
+or %r0, %r3
+or %r0, %r4
+or %r0, %r5
+or %r0, %r6
+or %r0, %r7
+or %r0, %r8
+or %r0, %r9
 
 exit
 -- result

--- a/tests/ldxh-all2.data
+++ b/tests/ldxh-all2.data
@@ -1,47 +1,47 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, r1
+mov %r0, %r1
 
-ldxh r9, [r0+0]
-be16 r9
+ldxh %r9, [%r0+0]
+be16 %r9
 
-ldxh r8, [r0+2]
-be16 r8
+ldxh %r8, [%r0+2]
+be16 %r8
 
-ldxh r7, [r0+4]
-be16 r7
+ldxh %r7, [%r0+4]
+be16 %r7
 
-ldxh r6, [r0+6]
-be16 r6
+ldxh %r6, [%r0+6]
+be16 %r6
 
-ldxh r5, [r0+8]
-be16 r5
+ldxh %r5, [%r0+8]
+be16 %r5
 
-ldxh r4, [r0+10]
-be16 r4
+ldxh %r4, [%r0+10]
+be16 %r4
 
-ldxh r3, [r0+12]
-be16 r3
+ldxh %r3, [%r0+12]
+be16 %r3
 
-ldxh r2, [r0+14]
-be16 r2
+ldxh %r2, [%r0+14]
+be16 %r2
 
-ldxh r1, [r0+16]
-be16 r1
+ldxh %r1, [%r0+16]
+be16 %r1
 
-ldxh r0, [r0+18]
-be16 r0
+ldxh %r0, [%r0+18]
+be16 %r0
 
-or r0, r1
-or r0, r2
-or r0, r3
-or r0, r4
-or r0, r5
-or r0, r6
-or r0, r7
-or r0, r8
-or r0, r9
+or %r0, %r1
+or %r0, %r2
+or %r0, %r3
+or %r0, %r4
+or %r0, %r5
+or %r0, %r6
+or %r0, %r7
+or %r0, %r8
+or %r0, %r9
 
 exit
 -- result

--- a/tests/ldxh-same-reg.data
+++ b/tests/ldxh-same-reg.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, r1
-sth [r0], 0x1234
-ldxh r0, [r0]
+mov %r0, %r1
+sth [%r0], 0x1234
+ldxh %r0, [%r0]
 exit
 -- mem
 ff ff

--- a/tests/ldxh.data
+++ b/tests/ldxh.data
@@ -1,7 +1,7 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-ldxh r0, [r1+2]
+ldxh %r0, [%r1+2]
 exit
 -- mem
 aa bb 11 22 cc dd

--- a/tests/ldxw-all.data
+++ b/tests/ldxw-all.data
@@ -1,47 +1,47 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, r1
+mov %r0, %r1
 
-ldxw r9, [r0+0]
-be32 r9
+ldxw %r9, [%r0+0]
+be32 %r9
 
-ldxw r8, [r0+4]
-be32 r8
+ldxw %r8, [%r0+4]
+be32 %r8
 
-ldxw r7, [r0+8]
-be32 r7
+ldxw %r7, [%r0+8]
+be32 %r7
 
-ldxw r6, [r0+12]
-be32 r6
+ldxw %r6, [%r0+12]
+be32 %r6
 
-ldxw r5, [r0+16]
-be32 r5
+ldxw %r5, [%r0+16]
+be32 %r5
 
-ldxw r4, [r0+20]
-be32 r4
+ldxw %r4, [%r0+20]
+be32 %r4
 
-ldxw r3, [r0+24]
-be32 r3
+ldxw %r3, [%r0+24]
+be32 %r3
 
-ldxw r2, [r0+28]
-be32 r2
+ldxw %r2, [%r0+28]
+be32 %r2
 
-ldxw r1, [r0+32]
-be32 r1
+ldxw %r1, [%r0+32]
+be32 %r1
 
-ldxw r0, [r0+36]
-be32 r0
+ldxw %r0, [%r0+36]
+be32 %r0
 
-or r0, r1
-or r0, r2
-or r0, r3
-or r0, r4
-or r0, r5
-or r0, r6
-or r0, r7
-or r0, r8
-or r0, r9
+or %r0, %r1
+or %r0, %r2
+or %r0, %r3
+or %r0, %r4
+or %r0, %r5
+or %r0, %r6
+or %r0, %r7
+or %r0, %r8
+or %r0, %r9
 
 exit
 -- result

--- a/tests/ldxw.data
+++ b/tests/ldxw.data
@@ -1,7 +1,7 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-ldxw r0, [r1+2]
+ldxw %r0, [%r1+2]
 exit
 -- mem
 aa bb 11 22 33 44 cc dd

--- a/tests/le16.data
+++ b/tests/le16.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-ldxh r0, [r1]
-le16 r0
+ldxh %r0, [%r1]
+le16 %r0
 exit
 -- mem
 22 11

--- a/tests/le32.data
+++ b/tests/le32.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-ldxw r0, [r1]
-le32 r0
+ldxw %r0, [%r1]
+le32 %r0
 exit
 -- mem
 44 33 22 11

--- a/tests/le64.data
+++ b/tests/le64.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-ldxdw r0, [r1]
-le64 r0
+ldxdw %r0, [%r1]
+le64 %r0
 exit
 -- mem
 88 77 66 55 44 33 22 11

--- a/tests/lock_add.data
+++ b/tests/lock_add.data
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0x123456789abcdef0
-stxdw [r10-8], r0
-mov r1, 1
-lock add [r10-8], r1
-ldxdw r1, [r10-8]
-lddw r0, 0x123456789abcdef1
-jne r0, r1, exit
-mov r0, 0
+lddw %r0, 0x123456789abcdef0
+stxdw [%r10-8], %r0
+mov %r1, 1
+lock add [%r10-8], %r1
+ldxdw %r1, [%r10-8]
+lddw %r0, 0x123456789abcdef1
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0x0

--- a/tests/lock_add32.data
+++ b/tests/lock_add32.data
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0x123456789abcdef0
-stxdw [r10-8], r0
-mov r1, 1
-lock add32 [r10-8], r1
-ldxdw r1, [r10-8]
-lddw r0, 0x123456789abcdef1
-jne r0, r1, exit
-mov r0, 0
+lddw %r0, 0x123456789abcdef0
+stxdw [%r10-8], %r0
+mov %r1, 1
+lock add32 [%r10-8], %r1
+ldxdw %r1, [%r10-8]
+lddw %r0, 0x123456789abcdef1
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0x0

--- a/tests/lock_and.data
+++ b/tests/lock_and.data
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0x123456789abcdef0
-stxdw [r10-8], r0
-lddw r1, 0x00ff00ff00ff00ff
-lock and [r10-8], r1
-ldxdw r0, [r10-8]
-lddw r1, 0x0034007800bc00f0
-jne r0, r1, exit
-mov r0, 0
+lddw %r0, 0x123456789abcdef0
+stxdw [%r10-8], %r0
+lddw %r1, 0x00ff00ff00ff00ff
+lock and [%r10-8], %r1
+ldxdw %r0, [%r10-8]
+lddw %r1, 0x0034007800bc00f0
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0x0

--- a/tests/lock_and32.data
+++ b/tests/lock_and32.data
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0x123456789abcdef0
-stxdw [r10-8], r0
-lddw r1, 0x00ff00ff00ff00ff
-lock and32 [r10-8], r1
-ldxdw r0, [r10-8]
-lddw r1, 0x1234567800bc00f0
-jne r0, r1, exit
-mov r0, 0
+lddw %r0, 0x123456789abcdef0
+stxdw [%r10-8], %r0
+lddw %r1, 0x00ff00ff00ff00ff
+lock and32 [%r10-8], %r1
+ldxdw %r0, [%r10-8]
+lddw %r1, 0x1234567800bc00f0
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0x0

--- a/tests/lock_cmpxchg.data
+++ b/tests/lock_cmpxchg.data
@@ -1,34 +1,34 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-# Store 0x123456789abcdef0 in [r10-8]
-lddw r0, 0x123456789abcdef0
-stxdw [r10-8], r0
-lddw r1, 0x1122334455667788
-lddw r0, 0xfedcba987654321
-# Expected to fail as [r10-8] != r1
-lock cmpxchg [r10-8], r1 # Atomically compare r0 and [r10-8] and set [r10-8] to r1 if matches.
-# Test if r0 contains value from [r10-8]
-lddw r1, 0x123456789abcdef0
-jne r0, r1, exit
-# Test if [r10-8] is unmodified
-ldxdw r0, [r10-8]
-jne r0, r1, exit
+# Store 0x123456789abcdef0 in [%r10-8]
+lddw %r0, 0x123456789abcdef0
+stxdw [%r10-8], %r0
+lddw %r1, 0x1122334455667788
+lddw %r0, 0xfedcba987654321
+# Expected to fail as [%r10-8] != %r1
+lock cmpxchg [%r10-8], %r1 # Atomically compare %r0 and [%r10-8] and set [%r10-8] to %r1 if matches.
+# Test if %r0 contains value from [%r10-8]
+lddw %r1, 0x123456789abcdef0
+jne %r0, %r1, exit
+# Test if [%r10-8] is unmodified
+ldxdw %r0, [%r10-8]
+jne %r0, %r1, exit
 
-lddw r0, 0x123456789abcdef0
-stxdw [r10-8], r0
-lddw r1, 0x1122334455667788
+lddw %r0, 0x123456789abcdef0
+stxdw [%r10-8], %r0
+lddw %r1, 0x1122334455667788
 # Expected to succeed
-lock cmpxchg [r10-8], r1 # Atomically compare r0 and [r10-8] and set [r10-8] to r1 if matches.
-# Test if r0 contains 0x123456789abcdef0
-lddw r1, 0x123456789abcdef0
-jne r0, r1, exit
-# Test if r0 contains value from [r10-8]
-ldxdw r0, [r10-8]
-lddw r1, 0x1122334455667788
-jne r0, r1, exit
+lock cmpxchg [%r10-8], %r1 # Atomically compare %r0 and [%r10-8] and set [%r10-8] to %r1 if matches.
+# Test if %r0 contains 0x123456789abcdef0
+lddw %r1, 0x123456789abcdef0
+jne %r0, %r1, exit
+# Test if %r0 contains value from [%r10-8]
+ldxdw %r0, [%r10-8]
+lddw %r1, 0x1122334455667788
+jne %r0, %r1, exit
 
-mov r0, 0
+mov %r0, 0
 exit
 -- result
 0x0

--- a/tests/lock_cmpxchg32.data
+++ b/tests/lock_cmpxchg32.data
@@ -1,35 +1,35 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0x123456789abcdef0
-stxdw [r10-8], r0
-mov32 r1, 0x876543210
-mov32 r0, 0x12345678
+lddw %r0, 0x123456789abcdef0
+stxdw [%r10-8], %r0
+mov32 %r1, 0x876543210
+mov32 %r0, 0x12345678
 # Expected to fail
-lock cmpxchg32 [r10-8], r1
-# Test if r0 contains 0x9abcdef0
-mov32 r1, 0x9abcdef0
-jne r0, r1, exit
-# Test if [r10-8] is unmodified
-ldxdw r0, [r10-8]
-lddw r1, 0x123456789abcdef0
-jne r0, r1, exit
+lock cmpxchg32 [%r10-8], %r1
+# Test if %r0 contains 0x9abcdef0
+mov32 %r1, 0x9abcdef0
+jne %r0, %r1, exit
+# Test if [%r10-8] is unmodified
+ldxdw %r0, [%r10-8]
+lddw %r1, 0x123456789abcdef0
+jne %r0, %r1, exit
 
-lddw r0, 0x123456789abcdef0
-stxdw [r10-8], r0
-mov32 r1, 0x11223344
+lddw %r0, 0x123456789abcdef0
+stxdw [%r10-8], %r0
+mov32 %r1, 0x11223344
 # Expected to succeed
-lock cmpxchg32 [r10-8], r1
-# Test if r0 contains 0x9abcdef0
-mov32 r1, 0x9abcdef0
-jne r0, r1, exit
+lock cmpxchg32 [%r10-8], %r1
+# Test if %r0 contains 0x9abcdef0
+mov32 %r1, 0x9abcdef0
+jne %r0, %r1, exit
 
-# Test if [r10-8] contains the expected value.
-ldxdw r0, [r10-8]
-lddw r1, 0x1234567811223344
-jne r0, r1, exit
+# Test if [%r10-8] contains the expected value.
+ldxdw %r0, [%r10-8]
+lddw %r1, 0x1234567811223344
+jne %r0, %r1, exit
 
-mov r0, 0
+mov %r0, 0
 exit
 -- result
 0x0

--- a/tests/lock_fetch_add.data
+++ b/tests/lock_fetch_add.data
@@ -1,15 +1,15 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0x123456789abcdef0
-stxdw [r10-8], r0
-mov r1, 1
-lock fetch add [r10-8], r1
-jne r1, r0, exit
-ldxdw r1, [r10-8]
-lddw r0, 0x123456789abcdef1
-jne r0, r1, exit
-mov r0, 0
+lddw %r0, 0x123456789abcdef0
+stxdw [%r10-8], %r0
+mov %r1, 1
+lock fetch add [%r10-8], %r1
+jne %r1, %r0, exit
+ldxdw %r1, [%r10-8]
+lddw %r0, 0x123456789abcdef1
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0x0

--- a/tests/lock_fetch_add32.data
+++ b/tests/lock_fetch_add32.data
@@ -1,15 +1,15 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0x123456789abcdef0
-stxdw [r10-8], r0
-mov r1, 1
-lock fetch add32 [r10-8], r1
-jne32 r1, r0, exit
-ldxdw r1, [r10-8]
-lddw r0, 0x123456789abcdef1
-jne r0, r1, exit
-mov r0, 0
+lddw %r0, 0x123456789abcdef0
+stxdw [%r10-8], %r0
+mov %r1, 1
+lock fetch add32 [%r10-8], %r1
+jne32 %r1, %r0, exit
+ldxdw %r1, [%r10-8]
+lddw %r0, 0x123456789abcdef1
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0x0

--- a/tests/lock_fetch_and.data
+++ b/tests/lock_fetch_and.data
@@ -1,15 +1,15 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0x123456789abcdef0
-stxdw [r10-8], r0
-lddw r1, 0x00ff00ff00ff00ff
-lock fetch and [r10-8], r1
-jne r1, r0, exit
-ldxdw r0, [r10-8]
-lddw r1, 0x0034007800bc00f0
-jne r0, r1, exit
-mov r0, 0
+lddw %r0, 0x123456789abcdef0
+stxdw [%r10-8], %r0
+lddw %r1, 0x00ff00ff00ff00ff
+lock fetch and [%r10-8], %r1
+jne %r1, %r0, exit
+ldxdw %r0, [%r10-8]
+lddw %r1, 0x0034007800bc00f0
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0x0

--- a/tests/lock_fetch_and32.data
+++ b/tests/lock_fetch_and32.data
@@ -1,15 +1,15 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0x123456789abcdef0
-stxdw [r10-8], r0
-lddw r1, 0x00ff00ff00ff00ff
-lock fetch and32 [r10-8], r1
-jne32 r1, r0, exit
-ldxdw r0, [r10-8]
-lddw r1, 0x1234567800bc00f0
-jne r0, r1, exit
-mov r0, 0
+lddw %r0, 0x123456789abcdef0
+stxdw [%r10-8], %r0
+lddw %r1, 0x00ff00ff00ff00ff
+lock fetch and32 [%r10-8], %r1
+jne32 %r1, %r0, exit
+ldxdw %r0, [%r10-8]
+lddw %r1, 0x1234567800bc00f0
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0x0

--- a/tests/lock_fetch_or.data
+++ b/tests/lock_fetch_or.data
@@ -1,15 +1,15 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0x1100110011001100
-lddw r1, 0x0011001100110011
-stxdw [r10-8], r0
-lock fetch or [r10-8], r1
-jne r1, r0, exit
-ldxdw r0, [r10-8]
-lddw r1, 0x1111111111111111
-jne r0, r1, exit
-mov r0, 0
+lddw %r0, 0x1100110011001100
+lddw %r1, 0x0011001100110011
+stxdw [%r10-8], %r0
+lock fetch or [%r10-8], %r1
+jne %r1, %r0, exit
+ldxdw %r0, [%r10-8]
+lddw %r1, 0x1111111111111111
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0

--- a/tests/lock_fetch_or32.data
+++ b/tests/lock_fetch_or32.data
@@ -1,16 +1,16 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0x1100110011001100
-lddw r1, 0x0011001100110011
-stxdw [r10-8], r0
-lock fetch or32 [r10-8], r1
-jne32 r1, r0, exit
-ldxdw r0, [r10-8]
+lddw %r0, 0x1100110011001100
+lddw %r1, 0x0011001100110011
+stxdw [%r10-8], %r0
+lock fetch or32 [%r10-8], %r1
+jne32 %r1, %r0, exit
+ldxdw %r0, [%r10-8]
 # Only lower 4 bytes are modified
-lddw r1, 0x1100110011111111
-jne r0, r1, exit
-mov r0, 0
+lddw %r1, 0x1100110011111111
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0

--- a/tests/lock_fetch_xor.data
+++ b/tests/lock_fetch_xor.data
@@ -1,15 +1,15 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0xcccccccccccccccc
-lddw r1, 0xffffffffffffffff
-stxdw [r10-8], r0
-lock fetch xor [r10-8], r1
-jne r1, r0, exit
-ldxdw r0, [r10-8]
-lddw r1, 0x3333333333333333
-jne r0, r1, exit
-mov r0, 0
+lddw %r0, 0xcccccccccccccccc
+lddw %r1, 0xffffffffffffffff
+stxdw [%r10-8], %r0
+lock fetch xor [%r10-8], %r1
+jne %r1, %r0, exit
+ldxdw %r0, [%r10-8]
+lddw %r1, 0x3333333333333333
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0

--- a/tests/lock_fetch_xor32.data
+++ b/tests/lock_fetch_xor32.data
@@ -1,15 +1,15 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0xcccccccccccccccc
-lddw r1, 0xffffffffffffffff
-stxdw [r10-8], r0
-lock fetch xor32 [r10-8], r1
-jne32 r1, r0, exit
-ldxdw r0, [r10-8]
-lddw r1, 0xcccccccc33333333
-jne r0, r1, exit
-mov r0, 0
+lddw %r0, 0xcccccccccccccccc
+lddw %r1, 0xffffffffffffffff
+stxdw [%r10-8], %r0
+lock fetch xor32 [%r10-8], %r1
+jne32 %r1, %r0, exit
+ldxdw %r0, [%r10-8]
+lddw %r1, 0xcccccccc33333333
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0

--- a/tests/lock_or.data
+++ b/tests/lock_or.data
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0x1100110011001100
-lddw r1, 0x0011001100110011
-stxdw [r10-8], r0
-lock or [r10-8], r1
-ldxdw r0, [r10-8]
-lddw r1, 0x1111111111111111
-jne r0, r1, exit
-mov r0, 0
+lddw %r0, 0x1100110011001100
+lddw %r1, 0x0011001100110011
+stxdw [%r10-8], %r0
+lock or [%r10-8], %r1
+ldxdw %r0, [%r10-8]
+lddw %r1, 0x1111111111111111
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0

--- a/tests/lock_or32.data
+++ b/tests/lock_or32.data
@@ -1,15 +1,15 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0x1100110011001100
-lddw r1, 0x0011001100110011
-stxdw [r10-8], r0
-lock or32 [r10-8], r1
-ldxdw r0, [r10-8]
+lddw %r0, 0x1100110011001100
+lddw %r1, 0x0011001100110011
+stxdw [%r10-8], %r0
+lock or32 [%r10-8], %r1
+ldxdw %r0, [%r10-8]
 # Only lower 4 bytes are modified
-lddw r1, 0x1100110011111111
-jne r0, r1, exit
-mov r0, 0
+lddw %r1, 0x1100110011111111
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0

--- a/tests/lock_xchg.data
+++ b/tests/lock_xchg.data
@@ -1,26 +1,26 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-mov r0, 0
-# Write 0x1111111111111111 to [r10-8]
-lddw r1, 0x1111111111111111
-stxdw [r10-8], r1
+mov %r0, 0
+# Write 0x1111111111111111 to [%r10-8]
+lddw %r1, 0x1111111111111111
+stxdw [%r10-8], %r1
 # Set the exchange value to 0x2222222222222222
-lddw r1, 0x2222222222222222
-# After the exchange, r1 should contain 0x1111111111111111 and
-# [r10-8] should contain 0x2222222222222222
-lock xchg [r10-8], r1
-# Check that the old value is stored in r0
-lddw r2, 0x1111111111111111
-jne r2, r0, exit
-# Check that [r10-8] contains 0x2222222222222222
-ldxdw r2, [r10-8]
-lddw r0, 0x2222222222222222
-jne r2, r0, exit
-# Check that r1 contains 0x1111111111111111
-lddw r0, 0x1111111111111111
-jne r1, r0, exit
-mov r0, 0
+lddw %r1, 0x2222222222222222
+# After the exchange, %r1 should contain 0x1111111111111111 and
+# [%r10-8] should contain 0x2222222222222222
+lock xchg [%r10-8], %r1
+# Check that the old value is stored in %r0
+lddw %r2, 0x1111111111111111
+jne %r2, %r0, exit
+# Check that [%r10-8] contains 0x2222222222222222
+ldxdw %r2, [%r10-8]
+lddw %r0, 0x2222222222222222
+jne %r2, %r0, exit
+# Check that %r1 contains 0x1111111111111111
+lddw %r0, 0x1111111111111111
+jne %r1, %r0, exit
+mov %r0, 0
 exit
 -- result
 0x0

--- a/tests/lock_xchg32.data
+++ b/tests/lock_xchg32.data
@@ -1,26 +1,26 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-mov r0, 0
-# Write 0x1111111111111111 to [r10-8]
-lddw r1, 0x1111111111111111
-stxdw [r10-8], r1
+mov %r0, 0
+# Write 0x1111111111111111 to [%r10-8]
+lddw %r1, 0x1111111111111111
+stxdw [%r10-8], %r1
 # Set the exchange value to 0x2222222222222222
-lddw r1, 0x2222222222222222
-# After the exchange, r1 should contain 0x11111111 and
-# [r10-8] should contain 0x1111111122222222
-lock xchg32 [r10-8], r1
-# Check that the old value is stored in r0
-lddw r2, 0x11111111
-jne r2, r0, exit
-# Check that [r10-8] contains 0x1111111122222222
-ldxdw r2, [r10-8]
-lddw r0, 0x1111111122222222
-jne r2, r0, exit
-# Check that r1 contains 0x11111111
-lddw r0, 0x11111111
-jne r1, r0, exit
-mov r0, 0
+lddw %r1, 0x2222222222222222
+# After the exchange, %r1 should contain 0x11111111 and
+# [%r10-8] should contain 0x1111111122222222
+lock xchg32 [%r10-8], %r1
+# Check that the old value is stored in %r0
+lddw %r2, 0x11111111
+jne %r2, %r0, exit
+# Check that [%r10-8] contains 0x1111111122222222
+ldxdw %r2, [%r10-8]
+lddw %r0, 0x1111111122222222
+jne %r2, %r0, exit
+# Check that %r1 contains 0x11111111
+lddw %r0, 0x11111111
+jne %r1, %r0, exit
+mov %r0, 0
 exit
 -- result
 0x0

--- a/tests/lock_xor.data
+++ b/tests/lock_xor.data
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0xcccccccccccccccc
-lddw r1, 0xffffffffffffffff
-stxdw [r10-8], r0
-lock xor [r10-8], r1
-ldxdw r0, [r10-8]
-lddw r1, 0x3333333333333333
-jne r0, r1, exit
-mov r0, 0
+lddw %r0, 0xcccccccccccccccc
+lddw %r1, 0xffffffffffffffff
+stxdw [%r10-8], %r0
+lock xor [%r10-8], %r1
+ldxdw %r0, [%r10-8]
+lddw %r1, 0x3333333333333333
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0

--- a/tests/lock_xor32.data
+++ b/tests/lock_xor32.data
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-lddw r0, 0xcccccccccccccccc
-lddw r1, 0xffffffffffffffff
-stxdw [r10-8], r0
-lock xor32 [r10-8], r1
-ldxdw r0, [r10-8]
-lddw r1, 0xcccccccc33333333
-jne r0, r1, exit
-mov r0, 0
+lddw %r0, 0xcccccccccccccccc
+lddw %r1, 0xffffffffffffffff
+stxdw [%r10-8], %r0
+lock xor32 [%r10-8], %r1
+ldxdw %r0, [%r10-8]
+lddw %r1, 0xcccccccc33333333
+jne %r0, %r1, exit
+mov %r0, 0
 exit
 -- result
 0

--- a/tests/lsh32-imm.data
+++ b/tests/lsh32-imm.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0x11
-lsh32 r0, 28
+mov %r0, 0x11
+lsh32 %r0, 28
 exit
 -- result
 0x10000000

--- a/tests/lsh32-reg.data
+++ b/tests/lsh32-reg.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0x11
-mov r7, 28
-lsh32 r0, r7
+mov %r0, 0x11
+mov %r7, 28
+lsh32 %r0, %r7
 exit
 -- result
 0x10000000

--- a/tests/lsh64-imm.data
+++ b/tests/lsh64-imm.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0x1
-lsh r0, 4
+mov %r0, 0x1
+lsh %r0, 4
 exit
 -- result
 0x10

--- a/tests/lsh64-reg.data
+++ b/tests/lsh64-reg.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0x1
-mov r7, 4
-lsh r0, r7
+mov %r0, 0x1
+mov %r7, 4
+lsh %r0, %r7
 exit
 -- result
 0x10

--- a/tests/mem-len.data
+++ b/tests/mem-len.data
@@ -1,7 +1,7 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, r2
+mov %r0, %r2
 exit
 -- mem
 00 00 00 01

--- a/tests/mod-by-zero-reg.data
+++ b/tests/mod-by-zero-reg.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 1
-mov32 r1, 0
-mod32 r0, r1
+mov32 %r0, 1
+mov32 %r1, 0
+mod32 %r0, %r1
 exit
 -- result
 0x1

--- a/tests/mod.data
+++ b/tests/mod.data
@@ -1,14 +1,14 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 5748
-mod32 r0, 92
-# r0 == 44
-jne r0, 44, exit
+mov32 %r0, 5748
+mod32 %r0, 92
+# %r0 == 44
+jne %r0, 44, exit
 
-mov32 r1, 13
-mod32 r0, r1
-# r0 == 5
+mov32 %r1, 13
+mod32 %r0, %r1
+# %r0 == 5
 
 exit
 -- result

--- a/tests/mod32.data
+++ b/tests/mod32.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-lddw r0, 0x100000003
-mod32 r0, 3
+lddw %r0, 0x100000003
+mod32 %r0, 3
 exit
 -- result
 0x0

--- a/tests/mod64-by-zero-reg.data
+++ b/tests/mod64-by-zero-reg.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 1
-mov32 r1, 0
-mod r0, r1
+mov32 %r0, 1
+mov32 %r1, 0
+mod %r0, %r1
 exit
 -- result
 0x1

--- a/tests/mod64.data
+++ b/tests/mod64.data
@@ -1,21 +1,21 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 0xb1858436
-lsh r0, 32
-or r0, 0x100dc5c8
-# r0 == 0xb1858436100dc5c8
+mov32 %r0, 0xb1858436
+lsh %r0, 32
+or %r0, 0x100dc5c8
+# %r0 == 0xb1858436100dc5c8
 
-mov32 r1, 0xdde263e
-lsh r1, 32
-or r1, 0x3cbef7f3
-# r1 == 0xdde263e3cbef7f3
+mov32 %r1, 0xdde263e
+lsh %r1, 32
+or %r1, 0x3cbef7f3
+# %r1 == 0xdde263e3cbef7f3
 
-mod r0, r1
-# r0 == 0xb1bb94b371a2664
+mod %r0, %r1
+# %r0 == 0xb1bb94b371a2664
 
-mod r0, 0x658f1778
-# r0 == 0x30ba5a04
+mod %r0, 0x658f1778
+# %r0 == 0x30ba5a04
 
 exit
 -- result

--- a/tests/mov.data
+++ b/tests/mov.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r1, 1
-mov32 r0, r1
+mov32 %r1, 1
+mov32 %r0, %r1
 exit
 -- result
 0x1

--- a/tests/mov64-sign-extend.data
+++ b/tests/mov64-sign-extend.data
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-mov r0, -10
+mov %r0, -10
 exit
 -- result
 0xFFFFFFFFFFFFFFF6

--- a/tests/mul32-imm.data
+++ b/tests/mul32-imm.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 3
-mul32 r0, 4
+mov %r0, 3
+mul32 %r0, 4
 exit
 -- result
 0xc

--- a/tests/mul32-reg-overflow.data
+++ b/tests/mul32-reg-overflow.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0x40000001
-mov r1, 4
-mul32 r0, r1
+mov %r0, 0x40000001
+mov %r1, 4
+mul32 %r0, %r1
 exit
 -- result
 0x4

--- a/tests/mul32-reg.data
+++ b/tests/mul32-reg.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 3
-mov r1, 4
-mul32 r0, r1
+mov %r0, 3
+mov %r1, 4
+mul32 %r0, %r1
 exit
 -- result
 0xc

--- a/tests/mul64-imm.data
+++ b/tests/mul64-imm.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0x40000001
-mul r0, 4
+mov %r0, 0x40000001
+mul %r0, 4
 exit
 -- result
 0x100000004

--- a/tests/mul64-reg.data
+++ b/tests/mul64-reg.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0x40000001
-mov r1, 4
-mul r0, r1
+mov %r0, 0x40000001
+mov %r1, 4
+mul %r0, %r1
 exit
 -- result
 0x100000004

--- a/tests/neg.data
+++ b/tests/neg.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 2
-neg32 r0
+mov32 %r0, 2
+neg32 %r0
 exit
 -- result
 0xfffffffe

--- a/tests/neg64.data
+++ b/tests/neg64.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r0, 2
-neg r0
+mov32 %r0, 2
+neg %r0
 exit
 -- result
 0xfffffffffffffffe

--- a/tests/prime.data
+++ b/tests/prime.data
@@ -16,24 +16,24 @@ uint64_t entry(uint64_t arg)
     return true;
 }
 -- asm
-mov r1, 67
-mov r0, 0x1
-mov r2, 0x2
-jgt r1, 0x2, L3
+mov %r1, 67
+mov %r0, 0x1
+mov %r2, 0x2
+jgt %r1, 0x2, L3
 L1:
 ja exit
 L2:
-add r2, 0x1
-mov r0, 0x1
-jge r2, r1, exit
+add %r2, 0x1
+mov %r0, 0x1
+jge %r2, %r1, exit
 L3:
-mov r3, r1
-div r3, r2
-mul r3, r2
-mov r4, r1
-sub r4, r3
-mov r0, 0x0
-jne r4, 0x0, L2
+mov %r3, %r1
+div %r3, %r2
+mul %r3, %r2
+mov %r4, %r1
+sub %r4, %r3
+mov %r0, 0x0
+jne %r4, 0x0, L2
 exit
 -- result
 0x1

--- a/tests/rsh32-imm.data
+++ b/tests/rsh32-imm.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0
-sub r0, 1
-rsh32 r0, 8
+mov %r0, 0
+sub %r0, 1
+rsh32 %r0, 8
 exit
 -- result
 0x00ffffff

--- a/tests/rsh32-reg.data
+++ b/tests/rsh32-reg.data
@@ -1,10 +1,10 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0
-sub r0, 1
-mov r7, 8
-rsh32 r0, r7
+mov %r0, 0
+sub %r0, 1
+mov %r7, 8
+rsh32 %r0, %r7
 exit
 -- result
 0x00ffffff

--- a/tests/rsh64-imm.data
+++ b/tests/rsh64-imm.data
@@ -1,8 +1,8 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0x10
-rsh r0, 4
+mov %r0, 0x10
+rsh %r0, 4
 exit
 -- result
 0x1

--- a/tests/rsh64-reg.data
+++ b/tests/rsh64-reg.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0x10
-mov r7, 4
-rsh r0, r7
+mov %r0, 0x10
+mov %r7, 4
+rsh %r0, %r7
 exit
 -- result
 0x1

--- a/tests/stack.data
+++ b/tests/stack.data
@@ -1,18 +1,18 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r1, 51
+mov %r1, 51
 
 # Create lookup table
-stdw [r10-16], 0xab
-stdw [r10-8], 0xcd
+stdw [%r10-16], 0xab
+stdw [%r10-8], 0xcd
 
-# Load lookup[r1 % 2]
-and r1, 1
-lsh r1, 3
-mov r2, r10
-add r2, r1
-ldxdw r0, [r2-16]
+# Load lookup[%r1 % 2]
+and %r1, 1
+lsh %r1, 3
+mov %r2, %r10
+add %r2, %r1
+ldxdw %r0, [%r2-16]
 
 exit
 -- result

--- a/tests/stb.data
+++ b/tests/stb.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-stb [r1+2], 0x11
-ldxb r0, [r1+2]
+stb [%r1+2], 0x11
+ldxb %r0, [%r1+2]
 exit
 -- mem
 aa bb ff cc dd

--- a/tests/stdw.data
+++ b/tests/stdw.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-stdw [r1+2], 0x44332211
-ldxdw r0, [r1+2]
+stdw [%r1+2], 0x44332211
+ldxdw %r0, [%r1+2]
 exit
 -- mem
 aa bb ff ff ff ff ff ff ff ff cc dd

--- a/tests/sth.data
+++ b/tests/sth.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-sth [r1+2], 0x2211
-ldxh r0, [r1+2]
+sth [%r1+2], 0x2211
+ldxh %r0, [%r1+2]
 exit
 -- mem
 aa bb ff ff cc dd

--- a/tests/stw.data
+++ b/tests/stw.data
@@ -1,8 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-stw [r1+2], 0x44332211
-ldxw r0, [r1+2]
+stw [%r1+2], 0x44332211
+ldxw %r0, [%r1+2]
 exit
 -- mem
 aa bb ff ff ff ff cc dd

--- a/tests/stxb-all.data
+++ b/tests/stxb-all.data
@@ -1,24 +1,24 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, 0xf0
-mov r2, 0xf2
-mov r3, 0xf3
-mov r4, 0xf4
-mov r5, 0xf5
-mov r6, 0xf6
-mov r7, 0xf7
-mov r8, 0xf8
-stxb [r1], r0
-stxb [r1+1], r2
-stxb [r1+2], r3
-stxb [r1+3], r4
-stxb [r1+4], r5
-stxb [r1+5], r6
-stxb [r1+6], r7
-stxb [r1+7], r8
-ldxdw r0, [r1]
-be64 r0
+mov %r0, 0xf0
+mov %r2, 0xf2
+mov %r3, 0xf3
+mov %r4, 0xf4
+mov %r5, 0xf5
+mov %r6, 0xf6
+mov %r7, 0xf7
+mov %r8, 0xf8
+stxb [%r1], %r0
+stxb [%r1+1], %r2
+stxb [%r1+2], %r3
+stxb [%r1+3], %r4
+stxb [%r1+4], %r5
+stxb [%r1+5], %r6
+stxb [%r1+6], %r7
+stxb [%r1+7], %r8
+ldxdw %r0, [%r1]
+be64 %r0
 exit
 -- mem
 ff ff ff ff ff ff ff ff

--- a/tests/stxb-all2.data
+++ b/tests/stxb-all2.data
@@ -1,13 +1,13 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, r1
-mov r1, 0xf1
-mov r9, 0xf9
-stxb [r0], r1
-stxb [r0+1], r9
-ldxh r0, [r0]
-be16 r0
+mov %r0, %r1
+mov %r1, 0xf1
+mov %r9, 0xf9
+stxb [%r0], %r1
+stxb [%r0+1], %r9
+ldxh %r0, [%r0]
+be16 %r0
 exit
 -- mem
 ff ff

--- a/tests/stxb-chain.data
+++ b/tests/stxb-chain.data
@@ -1,36 +1,36 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r0, r1
+mov %r0, %r1
 
-ldxb r9, [r0+0]
-stxb [r0+1], r9
+ldxb %r9, [%r0+0]
+stxb [%r0+1], %r9
 
-ldxb r8, [r0+1]
-stxb [r0+2], r8
+ldxb %r8, [%r0+1]
+stxb [%r0+2], %r8
 
-ldxb r7, [r0+2]
-stxb [r0+3], r7
+ldxb %r7, [%r0+2]
+stxb [%r0+3], %r7
 
-ldxb r6, [r0+3]
-stxb [r0+4], r6
+ldxb %r6, [%r0+3]
+stxb [%r0+4], %r6
 
-ldxb r5, [r0+4]
-stxb [r0+5], r5
+ldxb %r5, [%r0+4]
+stxb [%r0+5], %r5
 
-ldxb r4, [r0+5]
-stxb [r0+6], r4
+ldxb %r4, [%r0+5]
+stxb [%r0+6], %r4
 
-ldxb r3, [r0+6]
-stxb [r0+7], r3
+ldxb %r3, [%r0+6]
+stxb [%r0+7], %r3
 
-ldxb r2, [r0+7]
-stxb [r0+8], r2
+ldxb %r2, [%r0+7]
+stxb [%r0+8], %r2
 
-ldxb r1, [r0+8]
-stxb [r0+9], r1
+ldxb %r1, [%r0+8]
+stxb [%r0+9], %r1
 
-ldxb r0, [r0+9]
+ldxb %r0, [%r0+9]
 exit
 -- mem
 2a 00 00 00 00 00 00 00 00 00

--- a/tests/stxb.data
+++ b/tests/stxb.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r2, 0x11
-stxb [r1+2], r2
-ldxb r0, [r1+2]
+mov32 %r2, 0x11
+stxb [%r1+2], %r2
+ldxb %r0, [%r1+2]
 exit
 -- mem
 aa bb ff cc dd

--- a/tests/stxdw.data
+++ b/tests/stxdw.data
@@ -1,11 +1,11 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov r2, 0x88776655
-lsh r2, 32
-or r2, 0x44332211
-stxdw [r1+2], r2
-ldxdw r0, [r1+2]
+mov %r2, 0x88776655
+lsh %r2, 32
+or %r2, 0x44332211
+stxdw [%r1+2], %r2
+ldxdw %r0, [%r1+2]
 exit
 -- mem
 aa bb ff ff ff ff ff ff ff ff cc dd

--- a/tests/stxh.data
+++ b/tests/stxh.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r2, 0x2211
-stxh [r1+2], r2
-ldxh r0, [r1+2]
+mov32 %r2, 0x2211
+stxh [%r1+2], %r2
+ldxh %r0, [%r1+2]
 exit
 -- mem
 aa bb ff ff cc dd

--- a/tests/stxw.data
+++ b/tests/stxw.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 r2, 0x44332211
-stxw [r1+2], r2
-ldxw r0, [r1+2]
+mov32 %r2, 0x44332211
+stxw [%r1+2], %r2
+ldxw %r0, [%r1+2]
 exit
 -- mem
 aa bb ff ff ff ff cc dd

--- a/tests/subnet.data
+++ b/tests/subnet.data
@@ -57,21 +57,21 @@ uint64_t entry(void *mem)
     return 0;
 }
 -- asm
-mov r2, 0xe
-ldxh r3, [r1+12]
-jne r3, 0x81, L1
-mov r2, 0x12
-ldxh r3, [r1+16]
-and r3, 0xffff
+mov %r2, 0xe
+ldxh %r3, [%r1+12]
+jne %r3, 0x81, L1
+mov %r2, 0x12
+ldxh %r3, [%r1+16]
+and %r3, 0xffff
 L1:
-jne r3, 0x8, L2
-add r1, r2
-mov r0, 0x1
-ldxw r1, [r1+16]
-and r1, 0xffffff
-jeq r1, 0x1a8c0, exit
+jne %r3, 0x8, L2
+add %r1, %r2
+mov %r0, 0x1
+ldxw %r1, [%r1+16]
+and %r1, 0xffffff
+jeq %r1, 0x1a8c0, exit
 L2:
-mov r0, 0x0
+mov %r0, 0x0
 exit
 -- mem
 00 00 c0 9f a0 97 00 a0


### PR DESCRIPTION
GCC prefixes names with %. Switch over to using % as a name prefix to match GCC.