### PR TITLE
Add conformance tests for shifting out of range

### DIFF
--- a/tests/arsh32-reg-high.data
+++ b/tests/arsh32-reg-high.data
@@ -1,0 +1,12 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+
+-- asm
+mov32 %r0, 0xf8
+mov32 %r1, 48
+lsh32 %r0, 28
+# %r0 == 0x80000000
+arsh32 %r0, %r1
+exit
+-- result
+0xffff8000

--- a/tests/arsh32-reg-neg.data
+++ b/tests/arsh32-reg-neg.data
@@ -1,0 +1,12 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+
+-- asm
+mov32 %r0, 0xf8
+mov32 %r1, -16
+lsh32 %r0, 28
+# %r0 == 0x80000000
+arsh32 %r0, %r1
+exit
+-- result
+0xffff8000

--- a/tests/arsh64-imm.data
+++ b/tests/arsh64-imm.data
@@ -1,0 +1,9 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov32 %r0, 1
+lsh %r0, 63
+arsh %r0, 60
+exit
+-- result
+0xfffffffffffffff8

--- a/tests/arsh64-reg-high.data
+++ b/tests/arsh64-reg-high.data
@@ -1,0 +1,10 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov32 %r0, 1
+lsh %r0, 63
+mov32 %r1, 124
+arsh %r0, %r1
+exit
+-- result
+0xfffffffffffffff8

--- a/tests/arsh64-reg-neg.data
+++ b/tests/arsh64-reg-neg.data
@@ -3,8 +3,7 @@
 -- asm
 mov32 %r0, 1
 lsh %r0, 63
-arsh %r0, 55
-mov32 %r1, 5
+mov32 %r1, -4
 arsh %r0, %r1
 exit
 -- result

--- a/tests/arsh64-reg.data
+++ b/tests/arsh64-reg.data
@@ -1,0 +1,10 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov32 %r0, 1
+lsh %r0, 63
+mov32 %r1, 60
+arsh %r0, %r1
+exit
+-- result
+0xfffffffffffffff8

--- a/tests/lsh32-reg-high.data
+++ b/tests/lsh32-reg-high.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov %r0, 8
-lddw %r1, 0x100000001
-arsh32 %r0, %r1
+mov %r0, 0x11
+mov %r7, 60
+lsh32 %r0, %r7
 exit
 -- result
-0x4
+0x10000000

--- a/tests/lsh32-reg-neg.data
+++ b/tests/lsh32-reg-neg.data
@@ -1,0 +1,9 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov %r0, 0x11
+mov %r7, -4
+lsh32 %r0, %r7
+exit
+-- result
+0x10000000

--- a/tests/lsh64-reg-high.data
+++ b/tests/lsh64-reg-high.data
@@ -1,0 +1,9 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov %r0, 0x1
+mov %r7, 68
+lsh %r0, %r7
+exit
+-- result
+0x10

--- a/tests/lsh64-reg-neg.data
+++ b/tests/lsh64-reg-neg.data
@@ -1,0 +1,9 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov %r0, 0x1
+mov %r7, -60
+lsh %r0, %r7
+exit
+-- result
+0x10

--- a/tests/rsh32-reg-high.data
+++ b/tests/rsh32-reg-high.data
@@ -1,0 +1,10 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov %r0, 0
+sub %r0, 1
+mov %r7, 40
+rsh32 %r0, %r7
+exit
+-- result
+0x00ffffff

--- a/tests/rsh32-reg-neg.data
+++ b/tests/rsh32-reg-neg.data
@@ -1,0 +1,10 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov %r0, 0
+sub %r0, 1
+mov %r7, -24
+rsh32 %r0, %r7
+exit
+-- result
+0x00ffffff

--- a/tests/rsh64-reg-high.data
+++ b/tests/rsh64-reg-high.data
@@ -1,0 +1,9 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov %r0, 0x10
+mov %r7, 68
+rsh %r0, %r7
+exit
+-- result
+0x1

--- a/tests/rsh64-reg-neg.data
+++ b/tests/rsh64-reg-neg.data
@@ -1,0 +1,9 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov %r0, 0x10
+mov %r7, -60
+rsh %r0, %r7
+exit
+-- result
+0x1


### PR DESCRIPTION
The Linux verifier rejects shifting by imm out of range so did not add tests for those cases.
If there is a way to allow verifier rejection as "pass" we could add them for runtimes that do accept them.

Fixes #100 