### PR TITLE
Compare all 64-bits of return values with expected

### DIFF
--- a/.github/scripts/build-libbpf.sh
+++ b/.github/scripts/build-libbpf.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/bash
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+git clone https://github.com/libbpf/libbpf.git
+if [ $? -ne 0 ]; then
+	echo "Could not clone the libbpf repository."
+	exit 1
+fi
+
+# Jump in to the src directory to do the actual build.
+cd libbpf/src
+
+make
+if [ $? -ne 0 ]; then
+	echo "Could not build libbpf source."
+	exit 1
+fi
+
+# Now that the build was successful, install the library (shared
+# object and header files) in a spot where FindLibBpf.cmake can
+# find it when it is being built.
+sudo PREFIX=/usr LIBDIR=/usr/lib/x86_64-linux-gnu/ make install
+exit 0

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -42,13 +42,13 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - name: Install prerequisites - Ubuntu-22.04
-      if: inputs.platform == 'ubuntu-22.04'
+    - name: Install prerequisites - Ubuntu-latest
+      if: inputs.platform == 'ubuntu-latest'
       run: |
         sudo apt-get install -y libboost-dev \
          libboost-filesystem-dev \
          libboost-program-options-dev \
-         libbpf-dev \
+         libelf-dev \
          lcov
 
     - name: Install prerequisites - macos-11
@@ -59,6 +59,11 @@ jobs:
           ninja \
           ccache \
           boost
+
+    - name: Build/install libbpf From Source
+      if: inputs.platform == 'ubuntu-latest'
+      run: ./.github/scripts/build-libbpf.sh
+      shell: bash
 
     - name: Cache nuget packages
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
@@ -75,7 +80,7 @@ jobs:
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Configure CMake
-      if: inputs.platform == 'ubuntu-22.04' || inputs.platform == 'macos-11'
+      if: inputs.platform == 'ubuntu-latest' || inputs.platform == 'macos-11'
       run: |
         if [ "${{inputs.enable_sanitizers}}" = "true" ]; then
           export SANITIZER_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
@@ -119,7 +124,7 @@ jobs:
           ${{github.workspace}}/build/upload
 
     - name: Tests
-      if: inputs.platform == 'ubuntu-22.04'
+      if: inputs.platform == 'ubuntu-latest'
       working-directory: ${{github.workspace}}
       run: |
         cmake --build build --target test --

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -60,7 +60,7 @@ jobs:
   ubuntu_release:
     uses: ./.github/workflows/Build.yml
     with:
-      platform: ubuntu-22.04
+      platform: ubuntu-latest
       configuration: Release
       enable_sanitizers: false
       enable_coverage: false
@@ -69,7 +69,7 @@ jobs:
   ubuntu_debug:
     uses: ./.github/workflows/Build.yml
     with:
-      platform: ubuntu-22.04
+      platform: ubuntu-latest
       configuration: Debug
       enable_sanitizers: false
       enable_coverage: false
@@ -77,7 +77,7 @@ jobs:
   ubuntu_release_sanitizers:
     uses: ./.github/workflows/Build.yml
     with:
-      platform: ubuntu-22.04
+      platform: ubuntu-latest
       configuration: Release
       enable_sanitizers: true
       enable_coverage: false
@@ -85,7 +85,7 @@ jobs:
   ubuntu_debug_sanitizers:
     uses: ./.github/workflows/Build.yml
     with:
-      platform: ubuntu-22.04
+      platform: ubuntu-latest
       configuration: Debug
       enable_sanitizers: true
       enable_coverage: false
@@ -93,7 +93,7 @@ jobs:
   ubuntu_release_coverage:
     uses: ./.github/workflows/Build.yml
     with:
-      platform: ubuntu-22.04
+      platform: ubuntu-latest
       configuration: Release
       enable_sanitizers: false
       enable_coverage: true
@@ -101,7 +101,7 @@ jobs:
   ubuntu_debug_coverage:
     uses: ./.github/workflows/Build.yml
     with:
-      platform: ubuntu-22.04
+      platform: ubuntu-latest
       configuration: Debug
       enable_sanitizers: false
       enable_coverage: true
@@ -122,7 +122,7 @@ jobs:
     needs:
       - ubuntu_release_coverage
       - ubuntu_debug_coverage
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@v2.2.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -65,7 +65,11 @@ jobs:
 
     - name: Install prerequisites
       run: |
-        sudo apt-get install -y libboost-dev libboost-filesystem-dev libboost-program-options-dev libbpf-dev
+        sudo apt-get install -y libboost-dev libboost-filesystem-dev libboost-program-options-dev libelf-dev
+
+    - name: Build/install libbpf From Source
+      run: ./.github/scripts/build-libbpf.sh
+      shell: bash
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/include/bpf_conformance.h
+++ b/include/bpf_conformance.h
@@ -96,3 +96,7 @@ bpf_conformance(
     options.debug = debug;
     return bpf_conformance_options(test_files, plugin_path, plugin_options, options);
 }
+
+const std::string bpf_conformance_xdp_section_name = "xdp";
+const std::string bpf_conformance_default_section_name = ".text";
+const std::string bpf_conformance_default_function_name = "main";

--- a/negative/incorrect_return_value_high_bits.data
+++ b/negative/incorrect_return_value_high_bits.data
@@ -1,0 +1,9 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+ldxdw %r0, [%r1+2]
+exit
+-- mem
+aa bb 11 22 33 44 55 66 77 88 cc dd
+-- result
+0x8977665544332211

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,7 +118,7 @@ add_test(
 set_tests_properties(
   invalid_return_value
   PROPERTIES
-  PASS_REGULAR_EXPRESSION "Plugin returned invalid return value Hello World"
+  PASS_REGULAR_EXPRESSION "Plugin return value could not be parsed.*(.*Hello World.*)"
 )
 
 add_test(
@@ -173,7 +173,7 @@ add_test(
 set_tests_properties(
   expect_failure
   PROPERTIES
-  PASS_REGULAR_EXPRESSION "Plugin returned invalid return value This is a negative test"
+  PASS_REGULAR_EXPRESSION "Plugin return value could not be parsed.*(.*This is a negative test.*)"
 )
 
 add_test(
@@ -437,4 +437,15 @@ set_tests_properties(
 add_test(
   NAME back_compat
   COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_path ${PROJECT_BINARY_DIR}/tests/add.data --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin
+)
+
+add_test(
+  NAME incorrect_return_value_high_bits
+	COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_path ${PROJECT_SOURCE_DIR}/negative/incorrect_return_value_high_bits.data  --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --cpu_version v1 --xdp_prolog true --plugin_options "--debug"
+)
+
+set_tests_properties(
+  incorrect_return_value_high_bits
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION "incorrect return value.*9905498421827150353"
 )


### PR DESCRIPTION
Instead of considering only the 32 LSB when comparing the expected return values with the actual return values, consider all 64 bits.

Fixes #142