### PR TITLE
Move elfio into src/external

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "external/elfio"]
-	path = external/elfio
+[submodule "src/external/ELFIO"]
+	path = src/external/ELFIO
 	url = https://github.com/serge1/ELFIO.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "src/external/ELFIO"]
-	path = src/external/ELFIO
+[submodule "src/external/elfio"]
+	path = src/external/elfio
 	url = https://github.com/serge1/ELFIO.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,6 @@ include("cmake/FindLibBpf.cmake")
 include(CTest)
 
 add_subdirectory("src")
-if (EXISTS "${PROJECT_SOURCE_DIR}/external/elfio")
-add_subdirectory("external/elfio")
-else()
-message(FATAL_ERROR "Missing elfio -- initialize submodules recursively, please.")
-endif()
 
 file(COPY tests DESTINATION .)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,13 @@ add_library("bpf_conformance"
   bpf_writer.cc
 )
 
+if (EXISTS "${PROJECT_SOURCE_DIR}/src/external/elfio")
+add_subdirectory("external/elfio")
+else()
+message(FATAL_ERROR "Missing elfio -- initialize submodules recursively, please.")
+endif()
+
+
 add_executable(
   bpf_conformance_runner
   runner.cc


### PR DESCRIPTION
Resolves: #162 

The elfio submodule needs to be included as a source directory and included as an explicit dependency. By moving both into the src directory it permits other projects to take a dependency on just the src directory and skip building test code.