### PR TITLE
Use specific tag of libbpf

### DIFF
--- a/.github/scripts/build-libbpf.sh
+++ b/.github/scripts/build-libbpf.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 
-git clone https://github.com/libbpf/libbpf.git
+git clone --branch v1.3.0 https://github.com/libbpf/libbpf.git
 if [ $? -ne 0 ]; then
 	echo "Could not clone the libbpf repository."
 	exit 1


### PR DESCRIPTION
The script https://github.com/Alan-Jowett/bpf_conformance/blob/main/.github/scripts/build-libbpf.sh pulls the latest from libbpf, which causes the builds to be non-repeatable. Instead, it should clone the repo by tag to ensure builds are repeatable.