### PR TITLE
Remove tests for MOVSX with immediate

### DIFF
--- a/src/opcode_names.h
+++ b/src/opcode_names.h
@@ -25,7 +25,7 @@ inline bool
 needs_offset(uint8_t opcode)
 {
     return opcode == 0x34 || opcode == 0x37 || opcode == 0x3c || opcode == 0x3f || opcode == 0x94 || opcode == 0x97 ||
-           opcode == 0x9c || opcode == 0x9f || opcode == 0xb4 || opcode == 0xb7 || opcode == 0xbc || opcode == 0xbf;
+           opcode == 0x9c || opcode == 0x9f || opcode == 0xbc || opcode == 0xbf;
 }
 
 class bpf_conformance_instruction_t
@@ -309,14 +309,9 @@ static const std::set<bpf_conformance_instruction_t, InstCmp> instructions_from_
     {bpf_conformance_test_cpu_version_t::v3, 0xae},
     {bpf_conformance_test_cpu_version_t::v1, 0xaf},
     {bpf_conformance_test_cpu_version_t::v1, 0xb4, 0x00, 0x00, 0x00},
-    {bpf_conformance_test_cpu_version_t::v4, 0xb4, 0x00, 0x00, 0x08},
-    {bpf_conformance_test_cpu_version_t::v4, 0xb4, 0x00, 0x00, 0x10},
     {bpf_conformance_test_cpu_version_t::v2, 0xb5},
     {bpf_conformance_test_cpu_version_t::v3, 0xb6},
     {bpf_conformance_test_cpu_version_t::v1, 0xb7, 0x00, 0x00, 0x00},
-    {bpf_conformance_test_cpu_version_t::v4, 0xb7, 0x00, 0x00, 0x08},
-    {bpf_conformance_test_cpu_version_t::v4, 0xb7, 0x00, 0x00, 0x10},
-    {bpf_conformance_test_cpu_version_t::v4, 0xb7, 0x00, 0x00, 0x20},
     {bpf_conformance_test_cpu_version_t::v1, 0xbc, 0x00, 0x00, 0x00},
     {bpf_conformance_test_cpu_version_t::v4, 0xbc, 0x00, 0x00, 0x08},
     {bpf_conformance_test_cpu_version_t::v4, 0xbc, 0x00, 0x00, 0x10},

--- a/tests/movsx1632-imm.data
+++ b/tests/movsx1632-imm.data
@@ -1,7 +1,0 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
--- asm
-movsx1632 %r0, 0x89abcdef
-exit
--- result
-0xffffcdef

--- a/tests/movsx1664-imm.data
+++ b/tests/movsx1664-imm.data
@@ -1,7 +1,0 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
--- asm
-movsx1664 %r0, 0x89abcdef
-exit
--- result
-0xffffffffffffcdef

--- a/tests/movsx3264-imm.data
+++ b/tests/movsx3264-imm.data
@@ -1,7 +1,0 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
--- asm
-movsx3264 %r0, 0x89abcdef
-exit
--- result
-0xffffffff89abcdef

--- a/tests/movsx832-imm.data
+++ b/tests/movsx832-imm.data
@@ -1,7 +1,0 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
--- asm
-movsx832 %r0, 0x89abcdef
-exit
--- result
-0xffffffef

--- a/tests/movsx864-imm.data
+++ b/tests/movsx864-imm.data
@@ -1,7 +1,0 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
--- asm
-movsx864 %r0, 0x89abcdef
-exit
--- result
-0xffffffffffffffef


### PR DESCRIPTION
Per latest discussion on the mailing list at
https://mailarchive.ietf.org/arch/msg/bpf/uQiqhURdtxV_ZQOTgjCdm-seh74/ the MOVSX operation is only defined to support register extension.