### PR TITLE
Add additional corner cases to tests

### DIFF
--- a/tests/add.data
+++ b/tests/add.data
@@ -6,6 +6,7 @@ mov32 %r1, 2
 add32 %r0, 1
 add32 %r0, %r1
 add32 %r0, %r0
+add32 %r0, -3
 exit
 -- result
-0x6
+0x3

--- a/tests/add.data
+++ b/tests/add.data
@@ -5,6 +5,7 @@ mov32 %r0, 0
 mov32 %r1, 2
 add32 %r0, 1
 add32 %r0, %r1
+add32 %r0, %r0
 exit
 -- result
-0x3
+0x6

--- a/tests/add64.data
+++ b/tests/add64.data
@@ -1,8 +1,12 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov %r0, 1
-add %r0, -1
+mov %r0, 0
+mov %r1, 2
+add %r0, 1
+add %r0, %r1
+add %r0, %r0
+add %r0, -3
 exit
 -- result
-0
+0x3

--- a/tests/alu-arith.data
+++ b/tests/alu-arith.data
@@ -1,7 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 %r0, 0
+mov32 %r0, 10
+sub32 %r0, %r0
 mov32 %r1, 1
 mov32 %r2, 2
 mov32 %r3, 3

--- a/tests/alu-bit.data
+++ b/tests/alu-bit.data
@@ -15,12 +15,14 @@ jne %r0, 0, exit
 
 or32 %r0, %r5
 or32 %r0, 0xa0
+or32 %r0, %r0
 # %r0 == 0xa5
 jne %r0, 0xa5, exit
 
 and32 %r0, 0xa3
 mov32 %r9, 0x91
 and32 %r0, %r9
+and32 %r0, %r0
 # %r0 == 0x81
 jne %r0, 0x81, exit
 

--- a/tests/alu64-arith.data
+++ b/tests/alu64-arith.data
@@ -1,7 +1,8 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov %r0, 0
+mov %r0, 10
+sub %r0, %r0
 mov %r1, 1
 mov %r2, 2
 mov %r3, 3

--- a/tests/alu64-bit.data
+++ b/tests/alu64-bit.data
@@ -15,12 +15,14 @@ jne %r0, 0, exit
 
 or %r0, %r5
 or %r0, 0xa0
+or %r0, %r0
 # %r0 == 0xa5
 jne %r0, 0xa5, exit
 
 and %r0, 0xa3
 mov %r9, 0x91
 and %r0, %r9
+and %r0, %r0
 # %r0 == 0x81
 jne %r0, 0x81, exit
 

--- a/tests/jeq-reg.data
+++ b/tests/jeq-reg.data
@@ -5,6 +5,8 @@ mov32 %r0, 0
 mov32 %r1, 0xa
 mov32 %r2, 0xb
 jeq %r1, %r2, exit # Not taken
+jeq %r1, %r1, +1 # Taken
+exit
 
 mov32 %r0, 1
 mov32 %r1, 0xb

--- a/tests/jeq32-reg.data
+++ b/tests/jeq32-reg.data
@@ -8,6 +8,8 @@ mov32 %r0, 0
 mov32 %r1, 0xa
 mov32 %r2, 0xb
 jeq32 %r1, %r2, exit # Not taken
+jeq32 %r1, %r1, +1 # Taken
+exit
 
 mov32 %r0, 1
 mov32 %r1, 0xb

--- a/tests/jge-reg.data
+++ b/tests/jge-reg.data
@@ -1,24 +1,18 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-# Set %r9 to 0x100000000
-mov %r9, 1
-lsh %r9, 32
 mov32 %r0, 0
 mov32 %r1, 0xa
-mov32 %r2, 0xb
-jge32 %r1, %r2, exit # Not taken
-jge32 %r1, %r1, +1 # Taken
+mov32 %r2, 0x0b
+jge %r1, %r2, exit # Not taken
+jge %r1, %r1, +1 # Taken
 exit
 
 mov32 %r0, 1
-# set %r1 to 0x10000000c
 mov32 %r1, 0xc
-or %r1, %r9
-jge32 %r1, %r2, exit # Taken
+jge %r1, %r2, exit # Taken
 
 mov32 %r0, 2 # Skipped
-
 exit
 -- result
 0x1

--- a/tests/jne-reg.data
+++ b/tests/jne-reg.data
@@ -5,6 +5,7 @@ mov32 %r0, 0
 mov32 %r1, 0xb
 mov32 %r2, 0xb
 jne %r1, %r2, exit # Not taken
+jne %r1, %r1, exit # Not taken
 
 mov32 %r0, 1
 mov32 %r1, 0xa

--- a/tests/jne32-reg.data
+++ b/tests/jne32-reg.data
@@ -9,7 +9,8 @@ mov32 %r1, 0xb
 # set %r1 to 0x10000000b
 or %r1, %r9
 mov32 %r2, 0xb
-jne32 %r1, %r2, +4 # Not taken
+jne32 %r1, %r2, +5 # Not taken
+jne32 %r1, %r1, +4 # Not taken
 
 mov32 %r0, 1
 mov32 %r1, 0xa

--- a/tests/jset-reg.data
+++ b/tests/jset-reg.data
@@ -5,7 +5,7 @@ mov32 %r0, 0
 mov32 %r1, 0x7
 mov32 %r2, 0x8
 jset %r1, %r2, exit # Not taken
-jset $r1, %r1, +1 # Taken
+jset %r1, %r1, +1 # Taken
 exit
 
 mov32 %r0, 1

--- a/tests/jset-reg.data
+++ b/tests/jset-reg.data
@@ -5,6 +5,8 @@ mov32 %r0, 0
 mov32 %r1, 0x7
 mov32 %r2, 0x8
 jset %r1, %r2, exit # Not taken
+jset $r1, %r1, +1 # Taken
+exit
 
 mov32 %r0, 1
 mov32 %r1, 0x9

--- a/tests/jset32-reg.data
+++ b/tests/jset32-reg.data
@@ -10,6 +10,8 @@ mov32 %r1, 0x7
 or %r1, %r9
 mov32 %r2, 0x8
 jset32 %r1, %r2, exit # Not taken
+jset32 %r1, %r1, +1 # Taken
+exit
 
 mov32 %r0, 1
 mov32 %r1, 0x9

--- a/tests/jsge-reg.data
+++ b/tests/jsge-reg.data
@@ -7,6 +7,8 @@ mov %r2, 0xffffffff
 mov32 %r3, 0
 jsge %r1, %r2, exit # Not taken
 jsge %r1, %r3, exit # Not taken
+jsge %r1, %r1, +1 # Taken
+exit
 
 mov32 %r0, 1
 mov %r1, %r2

--- a/tests/jsge32-reg.data
+++ b/tests/jsge32-reg.data
@@ -12,6 +12,8 @@ mov %r2, 0xffffffff
 mov32 %r3, 0
 jsge32 %r1, %r2, exit # Not taken
 jsge32 %r1, %r3, exit # Not taken
+jsge32 %r1, %r1, +1 # Taken
+exit
 
 mov32 %r0, 1
 mov %r1, %r2

--- a/tests/jsgt-reg.data
+++ b/tests/jsgt-reg.data
@@ -5,6 +5,7 @@ mov32 %r0, 0
 mov %r1, 0xfffffffe
 mov %r2, 0xffffffff
 jsgt %r1, %r2, exit # Not taken
+jsgt %r1, %r1, exit # Not taken
 
 mov32 %r0, 1
 mov32 %r1, 0

--- a/tests/jsgt32-reg.data
+++ b/tests/jsgt32-reg.data
@@ -10,6 +10,7 @@ mov32 %r1, 0xfffffffe
 or %r1, %r9
 mov %r2, 0xffffffff
 jsgt32 %r1, %r2, exit # Not taken
+jsgt32 %r1, %r1, exit # Not taken
 
 mov32 %r0, 1
 mov32 %r1, 0

--- a/tests/jsle-reg.data
+++ b/tests/jsle-reg.data
@@ -8,6 +8,9 @@ mov32 %r3, 0
 jsle %r1, %r2, exit # Not taken
 jsle %r1, %r3, +1 # Taken
 exit
+jsle %r1, %r1, +1 # Taken
+exit
+
 mov32 %r0, 1
 mov %r1, %r2
 jsle %r1, %r2, +1 # Taken

--- a/tests/jsle32-reg.data
+++ b/tests/jsle32-reg.data
@@ -13,6 +13,9 @@ mov32 %r3, 0
 jsle32 %r1, %r2, exit # Not taken
 jsle32 %r1, %r3, +1 # Taken
 exit
+jsle32 %r1, %r1, +1 # Taken
+exit
+
 mov32 %r0, 1
 mov %r1, %r2
 jsle32 %r1, %r2, +1 # Taken

--- a/tests/mov64.data
+++ b/tests/mov64.data
@@ -1,9 +1,9 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 %r1, 1
-mov32 %r0, %r1
-mov32 %r0, %r0
+mov %r1, 1
+mov %r0, %r1
+mov %r0, %r0
 exit
 -- result
 0x1


### PR DESCRIPTION
For example, some j*reg.data tests checked comparison of a register with itself and others didn't, so this makes them more consistent.

Also updates various other tests to add the case where the src and dst register are the same.