### PR TITLE
Return bpf_conformance_test_cpu_version_t::unknown for unrecognized opcode sequence

### DIFF
--- a/include/bpf_conformance.h
+++ b/include/bpf_conformance.h
@@ -23,6 +23,7 @@ typedef enum class _bpf_conformance_test_cpu_version
     v2 = 2,
     v3 = 3,
     v4 = 4,
+    unknown = -1,
 } bpf_conformance_test_cpu_version_t;
 
 // Add typedef for backwards compatibility.

--- a/src/bpf_conformance.cc
+++ b/src/bpf_conformance.cc
@@ -139,6 +139,9 @@ get_instruction_cpu_version(ebpf_inst inst)
                (!needs_imm(inst.opcode) || instruction.imm == inst.imm) &&
                (!needs_offset(inst.opcode) || instruction.offset == inst.offset);
          });
+    if (instruction == instructions_from_spec.end()) {
+        return bpf_conformance_test_cpu_version_t::unknown;
+    }
     return instruction->cpu_version;
 }
 


### PR DESCRIPTION
Resolves: #190

Return bpf_conformance_test_cpu_version_t::unknown for unrecognized opcode sequence