### PR TITLE
Add conformance test for div32

### DIFF
--- a/tests/div32-by-zero-reg-2.data
+++ b/tests/div32-by-zero-reg-2.data
@@ -1,0 +1,7 @@
+-- asm
+mov32 %r0, 1
+lddw %r1, 0x100000000
+div32 %r0, %r1
+exit
+-- result
+0x0


### PR DESCRIPTION
This test that doing a div32 by a register that is not 0 but has its lower 32 bits to 0 is correct.