### PR TITLE
Make neg.data verify 32-bit operation

### DIFF
--- a/tests/neg.data
+++ b/tests/neg.data
@@ -1,7 +1,7 @@
 # Copyright (c) Big Switch Networks, Inc
 # SPDX-License-Identifier: Apache-2.0
 -- asm
-mov32 %r0, 2
+lddw %r0, 0x100000002
 neg32 %r0
 exit
 -- result


### PR DESCRIPTION
Update neg.data to verify that only the low 32 bits of the source register are used.