### PR TITLE
Add test for sign extension in jump operations

### DIFF
--- a/tests/j-signed-imm.data
+++ b/tests/j-signed-imm.data
@@ -1,5 +1,8 @@
 # Copyright (c) Alan Jowett
 # SPDX-License-Identifier: MIT
+# This test checks if the immediate value is sign extended when performing
+# unsigned jump operations.
+
 -- asm
 mov32 %r0, 2
 
@@ -17,6 +20,10 @@ exit
 
 lddw %r1, 0x80000000
 jne %r1, 0x80000000, +1 # Taken, sign extended
+exit
+
+lddw %r1, 0xFFFFFFFF00000000
+jset %r1, 0x80000000, +1 # Taken, sign extended
 exit
 
 mov32 %r0, 1

--- a/tests/j-signed-imm.data
+++ b/tests/j-signed-imm.data
@@ -1,0 +1,25 @@
+# Copyright (c) Alan Jowett
+# SPDX-License-Identifier: MIT
+-- asm
+mov32 %r0, 2
+
+lddw %r1, 0xFFFFFFFF80000000
+jeq %r1, 0x80000000, +1 # Taken, sign extended
+exit
+
+lddw %r1, 0xFFFFFFFF80000000
+jlt %r1, 0x80000001, +1 # Taken, sign extended
+exit
+
+lddw %r1, 0xFFFFFFFF80000001
+jgt %r1, 0x80000000, +1 # Taken, sign extended
+exit
+
+lddw %r1, 0x80000000
+jne %r1, 0x80000000, +1 # Taken, sign extended
+exit
+
+mov32 %r0, 1
+exit
+-- result
+0x1

--- a/tests/jlt-imm.data
+++ b/tests/jlt-imm.data
@@ -7,9 +7,6 @@ jlt %r1, 4, exit # Not taken
 jlt %r1, 5, exit # Not taken
 jlt %r1, 6, +1 # Taken
 exit
-mov32 %r0, 0x80000001
-jle %r0, 0x80000000, +1 # taken
-exit
 mov32 %r0, 1
 exit
 -- result

--- a/tests/jlt-imm.data
+++ b/tests/jlt-imm.data
@@ -7,6 +7,8 @@ jlt %r1, 4, exit # Not taken
 jlt %r1, 5, exit # Not taken
 jlt %r1, 6, +1 # Taken
 exit
+mov32 %r0, 0x80000001
+jle %r0, 0x80000000, +1 # Taken
 mov32 %r0, 1
 exit
 -- result

--- a/tests/jlt-imm.data
+++ b/tests/jlt-imm.data
@@ -8,7 +8,8 @@ jlt %r1, 5, exit # Not taken
 jlt %r1, 6, +1 # Taken
 exit
 mov32 %r0, 0x80000001
-jle %r0, 0x80000000, +1 # Taken
+jle %r0, 0x80000000, +1 # taken
+exit
 mov32 %r0, 1
 exit
 -- result


### PR DESCRIPTION
Add test to check if immediate value is correctly not sign extended when doing a comparison.