### PR TITLE
Rewrite mov.data test to include check for truncation

### DIFF
--- a/tests/mov.data
+++ b/tests/mov.data
@@ -1,9 +1,13 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Alan Jowett
+# SPDX-License-Identifier: MIT
 -- asm
-mov32 %r1, 1
+mov32 %r1, 2
 mov32 %r0, %r1
-mov32 %r0, %r0
+jne %r0, 2, exit
+lddw %r2, 0xFFFFFF00000002
+mov32 %r0, %r2
+jne %r0, 2, exit
+mov32 %r0, 1
 exit
 -- result
 0x1


### PR DESCRIPTION
Rewrite of the mov.data test (testing the 32bit MOV ALU operation) to include tests to check that the target register is correctly truncated.