### PR TITLE
Verify that bpf2bpf updates r10

### DIFF
--- a/tests/call_local.data
+++ b/tests/call_local.data
@@ -13,15 +13,25 @@ mov %r6, 6
 mov %r7, 7
 mov %r8, 8
 mov %r9, 9
+# Write to the stack to make sure it's preserved.
+stdw [%r10-4], 0x44332211
+stdw [%r10-8], 0x88776655
 call local func1
 # %r0 contains the return value
 # %r0 should contain 1 + 2 + 3 + 4 + 5
+# Write to the stack to make sure it's preserved.
 jne %r0, 15, failed
 # %r6 through %r9 should be preserved
 jne %r6, 6, failed
 jne %r7, 7, failed
 jne %r8, 8, failed
 jne %r9, 9, failed
+# Read back values from stack.
+ldxw %r6, [%r10-4]
+ldxw %r7, [%r10-8]
+# Check that the values were not overwritten by func1.
+jne %r6, 0x44332211, failed
+jne %r7, 0x88776655, failed
 # Success
 mov %r0, 1
 exit
@@ -36,6 +46,9 @@ add %r0, %r2
 add %r0, %r3
 add %r0, %r4
 add %r0, %r5
+# Write to the stack, shouldn't overwrite the callee's values.
+stdw [%r10-4], 0xCCBBAA99
+stdw [%r10-4], 0x00FFEEDD
 mov %r6, 0
 mov %r7, 0
 mov %r8, 0

--- a/tests/call_local.data
+++ b/tests/call_local.data
@@ -14,8 +14,8 @@ mov %r7, 7
 mov %r8, 8
 mov %r9, 9
 # Write to the stack to make sure it's preserved.
-stdw [%r10-4], 0x44332211
-stdw [%r10-8], 0x88776655
+stdw [%r10-8], 0x44332211
+stdw [%r10-16], 0x88776655
 call local func1
 # %r0 contains the return value
 # %r0 should contain 1 + 2 + 3 + 4 + 5
@@ -27,11 +27,13 @@ jne %r7, 7, failed
 jne %r8, 8, failed
 jne %r9, 9, failed
 # Read back values from stack.
-ldxw %r6, [%r10-4]
-ldxw %r7, [%r10-8]
 # Check that the values were not overwritten by func1.
-jne %r6, 0x44332211, failed
-jne %r7, 0x88776655, failed
+ldxw %r6, [%r10-8]
+mov32 %r0, 0x44332211
+jne %r6, %r0, failed
+ldxw %r7, [%r10-16]
+mov32 %r0, 0x88776655
+jne %r7, %r0, failed
 # Success
 mov %r0, 1
 exit
@@ -47,8 +49,8 @@ add %r0, %r3
 add %r0, %r4
 add %r0, %r5
 # Write to the stack, shouldn't overwrite the callee's values.
-stdw [%r10-4], 0xCCBBAA99
-stdw [%r10-4], 0x00FFEEDD
+stdw [%r10-8], 0xCCBBAA99
+stdw [%r10-16], 0x00FFEEDD
 mov %r6, 0
 mov %r7, 0
 mov %r8, 0


### PR DESCRIPTION
This pull request includes changes to the `tests/call_local.data` file to ensure that the stack is preserved during function calls. The changes involve writing to the stack before a function call and reading back the values after the call to check that they were not overwritten by the function. 

Stack preservation checks:

* [`tests/call_local.data`](diffhunk://#diff-eceb65308f7856362630d6e93163c8aaf8d24d457c505e3f549f800fb8f486efR16-R34): Added lines to write to the stack before calling `local func1` and read back the values after the call. This ensures that the values are preserved and not overwritten by `func1`.
* [`tests/call_local.data`](diffhunk://#diff-eceb65308f7856362630d6e93163c8aaf8d24d457c505e3f549f800fb8f486efR50-R51): Added lines to write to the stack in `stdw [%r10-4], 0xCCBBAA99`. This ensures that the stack writing operation does not overwrite the callee's values.