### PR TITLE
Check for truncation in LE operations

### DIFF
--- a/tests/le16-high.data
+++ b/tests/le16-high.data
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+-- asm
+ldxdw %r0, [%r1]
+le16 %r0
+exit
+-- mem
+22 11 00 FF EE DD CC BB AA
+-- result
+0x1122

--- a/tests/le32-high.data
+++ b/tests/le32-high.data
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+-- asm
+ldxw %r0, [%r1]
+le32 %r0
+exit
+-- mem
+44 33 22 11 00 FF EE DD
+-- result
+0x11223344


### PR DESCRIPTION
Add new tests to verify that le16 and le32 truncate the high bits of the target register.