### PR TITLE
Switch to macos-latest

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -56,8 +56,8 @@ jobs:
          libelf-dev \
          lcov
 
-    - name: Install prerequisites - macos-11
-      if: inputs.platform == 'macos-11'
+    - name: Install prerequisites - macos-latest
+      if: inputs.platform == 'macos-latest'
       run: |
         brew install \
           cmake \
@@ -85,7 +85,7 @@ jobs:
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Configure CMake
-      if: inputs.platform == 'ubuntu-latest' || inputs.platform == 'macos-11'
+      if: inputs.platform == 'ubuntu-latest' || inputs.platform == 'macos-latest'
       run: |
         if [ "${{inputs.enable_sanitizers}}" = "true" ]; then
           export SANITIZER_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -109,13 +109,13 @@ jobs:
   macos_release:
     uses: ./.github/workflows/Build.yml
     with:
-      platform: macos-11
+      platform: macos-latest
       configuration: Release
 
   macos_debug:
     uses: ./.github/workflows/Build.yml
     with:
-      platform: macos-11
+      platform: macos-latest
       configuration: Debug
 
   finish:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/CICD.yml` file. The change updates the platform for both `macos_release` and `macos_debug` jobs from `macos-11` to `macos-latest`. This means that these jobs will now run on the latest stable version of macOS available in the GitHub Actions environment.