### PR TITLE
Update le32-high.data

### DIFF
--- a/tests/le32-high.data
+++ b/tests/le32-high.data
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-ldxw %r0, [%r1]
+ldxdw %r0, [%r1]
 le32 %r0
 exit
 -- mem


### PR DESCRIPTION
This pull request includes a small change to the `tests/le32-high.data` file. The change modifies the assembly instruction from `ldxw` to `ldxdw`, which changes the data loading operation from loading a word to loading a double word.