### PR TITLE
Fix lock_xchg* test to return 1 on failure

### DIFF
--- a/tests/lock_xchg.data
+++ b/tests/lock_xchg.data
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-mov %r0, 0
+mov %r0, 1
 # Write 0x1111111111111111 to [%r10-8]
 lddw %r1, 0x1111111111111111
 stxdw [%r10-8], %r1
@@ -10,9 +10,6 @@ lddw %r1, 0x2222222222222222
 # After the exchange, %r1 should contain 0x1111111111111111 and
 # [%r10-8] should contain 0x2222222222222222
 lock xchg [%r10-8], %r1
-# Check that the old value is stored in %r0
-lddw %r2, 0x1111111111111111
-jne %r2, %r0, exit
 # Check that [%r10-8] contains 0x2222222222222222
 ldxdw %r2, [%r10-8]
 lddw %r0, 0x2222222222222222

--- a/tests/lock_xchg32.data
+++ b/tests/lock_xchg32.data
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 -- asm
-mov %r0, 0
+mov %r0, 1
 # Write 0x1111111111111111 to [%r10-8]
 lddw %r1, 0x1111111111111111
 stxdw [%r10-8], %r1
@@ -10,9 +10,6 @@ lddw %r1, 0x2222222222222222
 # After the exchange, %r1 should contain 0x11111111 and
 # [%r10-8] should contain 0x1111111122222222
 lock xchg32 [%r10-8], %r1
-# Check that the old value is stored in %r0
-lddw %r2, 0x11111111
-jne %r2, %r0, exit
 # Check that [%r10-8] contains 0x1111111122222222
 ldxdw %r2, [%r10-8]
 lddw %r0, 0x1111111122222222


### PR DESCRIPTION
Set %r0 at the start of the test. Only set %r0 to zero if all the checks pass.

Resolves: #227 