### PR TITLE
Replace newlines in error output

### DIFF
--- a/src/bpf_conformance.cc
+++ b/src/bpf_conformance.cc
@@ -370,7 +370,7 @@ bpf_conformance_options(
         if (return_value != expected_return_value) {
             test_results[test] = {
                 bpf_conformance_test_result_t::TEST_RESULT_FAIL,
-                "Plugin returned incorrect return value " + return_value_string + " expected " +
+                "Plugin returned incorrect return value " + std::to_string(return_value) + " expected " +
                     std::to_string(expected_return_value)};
         } else {
             test_results[test] = {bpf_conformance_test_result_t::TEST_RESULT_PASS, ""};

--- a/src/bpf_conformance.cc
+++ b/src/bpf_conformance.cc
@@ -293,6 +293,17 @@ bpf_conformance_options(
             while (std::getline(error, line)) {
                 error_string += line + "\n";
             }
+
+            // Strip the trailing newline from the return value.
+            if (return_value_string.empty()) {
+                return_value_string = return_value_string.substr(0, return_value_string.size() - 1);
+            }
+
+            // Strip the trailing newline from the error string.
+            if (error_string.empty()) {
+                error_string = error_string.substr(0, error_string.size() - 1);
+            }
+
             c.wait();
 
             // If the plugin returned a non-zero exit code, then check to see if the error string matches the expected

--- a/src/bpf_conformance.cc
+++ b/src/bpf_conformance.cc
@@ -286,12 +286,12 @@ bpf_conformance_options(
 
             // Read the return value from the plugin from stdout.
             while (std::getline(output, line)) {
-                return_value_string += line;
+                return_value_string += line + "\n";
             }
             output.close();
 
             while (std::getline(error, line)) {
-                error_string += line;
+                error_string += line + "\n";
             }
             c.wait();
 


### PR DESCRIPTION
This pull request includes changes to the `bpf_conformance_options` function in the `src/bpf_conformance.cc` file. The changes are aimed at modifying the way output and error strings are concatenated. Instead of simply appending each new line to the existing string, the updated code also adds a newline character at the end of each line. This will ensure that each line of output or error is preserved on a new line in the respective string, improving readability and debugging if necessary.