### PR TITLE
Strip whitespace before comparing returned strings

### DIFF
--- a/src/bpf_conformance.cc
+++ b/src/bpf_conformance.cc
@@ -322,6 +322,10 @@ bpf_conformance_options(
                     if (cr != std::string::npos) {
                         return_value_string = return_value_string.substr(0, cr);
                     }
+
+                    // Strip any trailing whitespace from the return value.
+                    return_value_string = std::regex_replace(return_value_string, std::regex("\\s+$"), "");
+
                     if (expected_error_string == return_value_string) {
                         test_results[test] = {bpf_conformance_test_result_t::TEST_RESULT_PASS, ""};
 


### PR DESCRIPTION
This pull request includes a change to the `bpf_conformance_options` function in `src/bpf_conformance.cc` to improve the handling of return values. The most important change is the addition of a step to strip any trailing whitespace from the return value string.

Improvements to return value handling:

* [`src/bpf_conformance.cc`](diffhunk://#diff-a629e11824b7ef0e5e934ff2ae700032b2d2ea3dd4a33b029ec2f34082057993R325-R328): Added a step to strip any trailing whitespace from the `return_value_string` using a regular expression replacement.