### PR TITLE
Group similar dependabot changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,37 +14,59 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "saturday"
-
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "saturday"
-
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "saturday"
-
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "saturday"
-
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: docker
     directory: /Docker/Linux
     schedule:
       interval: daily
-
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: docker
     directory: /Docker/Windows
     schedule:
       interval: daily
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request includes changes to the `.github/dependabot.yml` file to group dependencies by patterns for better organization and management.

Configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L17-R72): Added `groups` with `actions` and `patterns` to each package-ecosystem configuration to group dependencies by patterns.