### PR TITLE
Enable merge_group trigger

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -13,6 +13,7 @@ on:
   # Run on a daily schedule to perform the full set of tests.
   schedule:
     - cron: '00 21 * * *'
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/CICD.yml` file. The change adds a `merge_group` trigger to the workflow configuration.

* [`.github/workflows/CICD.yml`](diffhunk://#diff-fdc42f85e64d73f2d88830f87cfb3c6f32c93a440ed1aaaf6bfbcb8648fb9defR16): Added `merge_group` trigger to the workflow configuration.