### PR TITLE
Add test cases for INTMIN and -1

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -71,7 +71,7 @@ jobs:
       shell: bash
 
     - name: Cache nuget packages
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      if: ${{ startsWith(inputs.platform, 'windows-') }}
       uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8
       env:
         cache-name: cache-nuget-modules
@@ -80,12 +80,12 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}-${{inputs.platform}}
 
     - name: Configure CMake (Windows)
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      if: ${{ startsWith(inputs.platform, 'windows-') }}
       run: |
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Configure CMake (non-Windows)
-      if: ${{ startsWith(inputs.platform, 'ubuntu-') }} || inputs.platform == 'macos-latest'
+      if: ${{ !startsWith(inputs.platform, 'windows-') }}
       run: |
         if [ "${{inputs.enable_sanitizers}}" = "true" ]; then
           export SANITIZER_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -47,8 +47,8 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - name: Install prerequisites - Ubuntu-latest
-      if: inputs.platform == 'ubuntu-latest'
+    - name: Install prerequisites - Ubuntu
+      if: ${{ startsWith(inputs.platform, 'ubuntu-') }}
       run: |
         sudo apt-get install -y libboost-dev \
          libboost-filesystem-dev \
@@ -66,7 +66,7 @@ jobs:
           boost
 
     - name: Build/install libbpf From Source
-      if: inputs.platform == 'ubuntu-latest'
+      if: ${{ startsWith(inputs.platform, 'ubuntu-') }}
       run: ./.github/scripts/build-libbpf.sh
       shell: bash
 
@@ -79,13 +79,13 @@ jobs:
         path: build\packages
         key: ${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}-${{inputs.platform}}
 
-    - name: Configure CMake
+    - name: Configure CMake (Windows)
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
       run: |
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
-    - name: Configure CMake
-      if: inputs.platform == 'ubuntu-latest' || inputs.platform == 'macos-latest'
+    - name: Configure CMake (non-Windows)
+      if: ${{ startsWith(inputs.platform, 'ubuntu-') }} || inputs.platform == 'macos-latest'
       run: |
         if [ "${{inputs.enable_sanitizers}}" = "true" ]; then
           export SANITIZER_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
@@ -129,7 +129,7 @@ jobs:
           ${{github.workspace}}/build/upload
 
     - name: Tests
-      if: inputs.platform == 'ubuntu-latest'
+      if: ${{ startsWith(inputs.platform, 'ubuntu-') }}
       working-directory: ${{github.workspace}}
       run: |
         cmake --build build --target test --

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -61,7 +61,7 @@ jobs:
   ubuntu_release:
     uses: ./.github/workflows/Build.yml
     with:
-      platform: ubuntu-latest
+      platform: ubuntu-22.04
       configuration: Release
       enable_sanitizers: false
       enable_coverage: false
@@ -94,7 +94,7 @@ jobs:
   ubuntu_release_coverage:
     uses: ./.github/workflows/Build.yml
     with:
-      platform: ubuntu-latest
+      platform: ubuntu-22.04
       configuration: Release
       enable_sanitizers: false
       enable_coverage: true

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,22 +81,22 @@ enable_testing()
 
 add_test(
   NAME cpu_v1
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v1 --exclude_regex "imm-" --exclude_groups callx
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v1 --exclude_regex "(imm|negone)-" --exclude_groups callx
 )
 
 add_test(
   NAME cpu_v2
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v2 --exclude_regex "imm-" --exclude_groups callx
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v2 --exclude_regex "(imm|negone)-" --exclude_groups callx
 )
 
 add_test(
   NAME cpu_v3
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v3 --debug true --list_instructions true --exclude_regex "imm-" --exclude_groups callx
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v3 --debug true --list_instructions true --exclude_regex "(imm|negone)-" --exclude_groups callx
 )
 
 add_test(
   NAME elf_format
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v3 --debug true --list_instructions true --elf true --exclude_regex "(call_local*|imm-)" --exclude_groups callx
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v3 --debug true --list_instructions true --elf true --exclude_regex "(call_local*|imm-|negone-)" --exclude_groups callx
 )
 
 add_test(
@@ -414,7 +414,7 @@ set_tests_properties(
 
 add_test(
   NAME list_used_instructions
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v1 --list_used_instructions true
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v1 --exclude_regex "negone-" --list_used_instructions true
 )
 
 set_tests_properties(
@@ -425,7 +425,7 @@ set_tests_properties(
 
 add_test(
   NAME list_unused_instructions
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --cpu_version v1 --list_unused_instructions true
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --cpu_version v1 --exclude_regex "negone-" --list_unused_instructions true
 )
 
 set_tests_properties(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,22 +81,22 @@ enable_testing()
 
 add_test(
   NAME cpu_v1
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v1 --exclude_regex "(imm|negone)-" --exclude_groups callx
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v1 --exclude_regex "(imm|intmin)-" --exclude_groups callx
 )
 
 add_test(
   NAME cpu_v2
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v2 --exclude_regex "(imm|negone)-" --exclude_groups callx
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v2 --exclude_regex "(imm|intmin)-" --exclude_groups callx
 )
 
 add_test(
   NAME cpu_v3
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v3 --debug true --list_instructions true --exclude_regex "(imm|negone)-" --exclude_groups callx
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v3 --debug true --list_instructions true --exclude_regex "(imm|intmin)-" --exclude_groups callx
 )
 
 add_test(
   NAME elf_format
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v3 --debug true --list_instructions true --elf true --exclude_regex "(call_local*|imm-|negone-)" --exclude_groups callx
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v3 --debug true --list_instructions true --elf true --exclude_regex "(call_local*|imm-|intmin-)" --exclude_groups callx
 )
 
 add_test(
@@ -414,7 +414,7 @@ set_tests_properties(
 
 add_test(
   NAME list_used_instructions
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v1 --exclude_regex "negone-" --list_used_instructions true
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v1 --exclude_regex "intmin-" --list_used_instructions true
 )
 
 set_tests_properties(
@@ -425,7 +425,7 @@ set_tests_properties(
 
 add_test(
   NAME list_unused_instructions
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --cpu_version v1 --exclude_regex "negone-" --list_unused_instructions true
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --cpu_version v1 --exclude_regex "intmin-" --list_unused_instructions true
 )
 
 set_tests_properties(

--- a/tests/mul32-intmin-by-negone-imm.data
+++ b/tests/mul32-intmin-by-negone-imm.data
@@ -1,5 +1,5 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
 -- asm
 mov %r0, 0x80000000
 mul32 %r0, -1

--- a/tests/mul32-intmin-by-negone-imm.data
+++ b/tests/mul32-intmin-by-negone-imm.data
@@ -1,0 +1,8 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov %r0, 0x80000000
+mul32 %r0, -1
+exit
+-- result
+0x80000000

--- a/tests/mul32-intmin-by-negone-reg.data
+++ b/tests/mul32-intmin-by-negone-reg.data
@@ -1,5 +1,5 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
 -- asm
 mov %r0, 0x80000000
 mov %r1, -1

--- a/tests/mul32-intmin-by-negone-reg.data
+++ b/tests/mul32-intmin-by-negone-reg.data
@@ -1,0 +1,9 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov %r0, 0x80000000
+mov %r1, -1
+mul32 %r0, %r1
+exit
+-- result
+0x80000000

--- a/tests/mul64-intmin-by-negone-imm.data
+++ b/tests/mul64-intmin-by-negone-imm.data
@@ -1,0 +1,10 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+ldxdw %r0, [%r1]
+mul %r0, -1
+exit
+-- mem
+00 00 00 00 00 00 00 80
+-- result
+0x8000000000000000

--- a/tests/mul64-intmin-by-negone-imm.data
+++ b/tests/mul64-intmin-by-negone-imm.data
@@ -1,5 +1,5 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
 -- asm
 ldxdw %r0, [%r1]
 mul %r0, -1

--- a/tests/mul64-intmin-by-negone-reg.data
+++ b/tests/mul64-intmin-by-negone-reg.data
@@ -1,0 +1,11 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+ldxdw %r0, [%r1]
+mov %r1, -1
+mul %r0, %r1
+exit
+-- mem
+00 00 00 00 00 00 00 80
+-- result
+0x8000000000000000

--- a/tests/mul64-intmin-by-negone-reg.data
+++ b/tests/mul64-intmin-by-negone-reg.data
@@ -1,5 +1,5 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
 -- asm
 ldxdw %r0, [%r1]
 mov %r1, -1

--- a/tests/neg32-intmin-imm.data
+++ b/tests/neg32-intmin-imm.data
@@ -1,0 +1,8 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+lddw %r0, 0x80000000
+neg32 %r0
+exit
+-- result
+0x80000000

--- a/tests/neg32-intmin-imm.data
+++ b/tests/neg32-intmin-imm.data
@@ -1,5 +1,5 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
 -- asm
 lddw %r0, 0x80000000
 neg32 %r0

--- a/tests/neg32-intmin-reg.data
+++ b/tests/neg32-intmin-reg.data
@@ -1,5 +1,5 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
 -- asm
 mov %r0, 0x80000000
 neg32 %r0

--- a/tests/neg32-intmin-reg.data
+++ b/tests/neg32-intmin-reg.data
@@ -1,0 +1,9 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov %r0, 0x80000000
+mov %r1, -1
+neg32 %r0
+exit
+-- result
+0x80000000

--- a/tests/neg32-intmin-reg.data
+++ b/tests/neg32-intmin-reg.data
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 -- asm
 mov %r0, 0x80000000
-mov %r1, -1
 neg32 %r0
 exit
 -- result

--- a/tests/neg64-intmin-imm.data
+++ b/tests/neg64-intmin-imm.data
@@ -1,5 +1,5 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
 -- asm
 ldxdw %r0, [%r1]
 neg %r0

--- a/tests/neg64-intmin-imm.data
+++ b/tests/neg64-intmin-imm.data
@@ -1,0 +1,10 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+ldxdw %r0, [%r1]
+neg %r0
+exit
+-- mem
+00 00 00 00 00 00 00 80
+-- result
+0x8000000000000000

--- a/tests/neg64-intmin-reg.data
+++ b/tests/neg64-intmin-reg.data
@@ -1,0 +1,11 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+ldxdw %r0, [%r1]
+mov %r1, -1
+neg %r0
+exit
+-- mem
+00 00 00 00 00 00 00 80
+-- result
+0x8000000000000000

--- a/tests/neg64-intmin-reg.data
+++ b/tests/neg64-intmin-reg.data
@@ -1,5 +1,5 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
 -- asm
 ldxdw %r0, [%r1]
 mov %r1, -1

--- a/tests/sdiv32-intmin-by-negone-imm.data
+++ b/tests/sdiv32-intmin-by-negone-imm.data
@@ -1,0 +1,8 @@
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
+-- asm
+mov32 %r0, 0x80000000
+sdiv32 %r0, -1
+exit
+-- result
+0x80000000

--- a/tests/sdiv32-intmin-by-negone-reg.data
+++ b/tests/sdiv32-intmin-by-negone-reg.data
@@ -1,5 +1,5 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
 -- asm
 mov32 %r0, 0x80000000
 mov32 %r1, -1

--- a/tests/sdiv32-intmin-by-negone-reg.data
+++ b/tests/sdiv32-intmin-by-negone-reg.data
@@ -1,0 +1,9 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov32 %r0, 0x80000000
+mov32 %r1, -1
+sdiv32 %r0, %r1
+exit
+-- result
+0x80000000

--- a/tests/sdiv64-intmin-by-negone-imm.data
+++ b/tests/sdiv64-intmin-by-negone-imm.data
@@ -1,0 +1,10 @@
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
+-- asm
+ldxdw %r0, [%r1]
+sdiv %r0, -1
+exit
+-- mem
+00 00 00 00 00 00 00 80
+-- result
+0x8000000000000000

--- a/tests/sdiv64-intmin-by-negone-reg.data
+++ b/tests/sdiv64-intmin-by-negone-reg.data
@@ -1,5 +1,5 @@
-# Copyright (c) Big Switch Networks, Inc
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
 -- asm
 ldxdw %r0, [%r1]
 mov %r1, -1

--- a/tests/sdiv64-intmin-by-negone-reg.data
+++ b/tests/sdiv64-intmin-by-negone-reg.data
@@ -1,0 +1,11 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+ldxdw %r0, [%r1]
+mov %r1, -1
+sdiv %r0, %r1
+exit
+-- mem
+00 00 00 00 00 00 00 80
+-- result
+0x8000000000000000

--- a/tests/smod32-intmin-by-negone-imm.data
+++ b/tests/smod32-intmin-by-negone-imm.data
@@ -1,0 +1,8 @@
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
+-- asm
+mov32 %r0, 0x80000000
+smod32 %r0, -1
+exit
+-- result
+0x0

--- a/tests/smod32-intmin-by-negone-reg.data
+++ b/tests/smod32-intmin-by-negone-reg.data
@@ -1,0 +1,9 @@
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
+-- asm
+mov32 %r0, 0x80000000
+mov32 %r1, -1
+smod32 %r0, %r1
+exit
+-- result
+0x0

--- a/tests/smod64-intmin-by-negone-imm.data
+++ b/tests/smod64-intmin-by-negone-imm.data
@@ -1,0 +1,10 @@
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
+-- asm
+ldxdw %r0, [%r1]
+smod %r0, -1
+exit
+-- mem
+00 00 00 00 00 00 00 80
+-- result
+0x0

--- a/tests/smod64-intmin-by-negone-reg.data
+++ b/tests/smod64-intmin-by-negone-reg.data
@@ -1,0 +1,11 @@
+# Copyright (c) Dave Thaler
+# SPDX-License-Identifier: MIT
+-- asm
+ldxdw %r0, [%r1]
+mov %r1, -1
+smod %r0, %r1
+exit
+-- mem
+00 00 00 00 00 00 00 80
+-- result
+0x0


### PR DESCRIPTION
INTMIN * -1 => INTMIN.
See https://mailarchive.ietf.org/arch/msg/bpf/nvaEmn-ydpHd0_0CvEzELp092FU/ for discussion

This PR adds test cases for NEG, MUL, SDIV, and SMOD

I verified all test cases using ebpf-verifier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Introduced new test cases for assembly operations involving minimum values of 32-bit and 64-bit signed integers, covering multiplication, negation, signed division, and signed modulus with negative one as an operand.
	- Added specific test cases for the `neg32` and `neg64` instructions validating their behavior with the input value `0x80000000`.
	- Updated existing tests to broaden exclusion criteria for improved test execution.
- **Chores**
	- Updated CI/CD workflow configuration to specify `ubuntu-22.04` for certain jobs, enhancing consistency in the build environment.
	- Modified build workflow conditions to improve flexibility for Ubuntu platform checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->