### PR TITLE
Add step to upload build output to diagnose failures

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -134,6 +134,19 @@ jobs:
       run: |
         cmake --build build --target test --
 
+    - name: Rerun failed tests with more verbose output
+      if: inputs.platform == 'ubuntu-latest' && failure()
+      working-directory: ${{github.workspace}}/build
+      run: |
+        ctest --rerun-failed --output-on-failure
+
+    - name: Upload build folder for diagnosing issues
+      if: always()
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      with:
+        name: bpf_conformance-diagnostic-${{inputs.platform}}-${{inputs.configuration}}-enable-sanitizers-${{inputs.enable_sanitizers}}-enable-coverage-${{inputs.enable_coverage}}
+        path: ${{github.workspace}}/build
+
     - name: Generate code coverage report
       if: inputs.enable_coverage == true
       run: |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,22 +81,22 @@ enable_testing()
 
 add_test(
   NAME cpu_v1
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v1 --exclude_regex "(imm|intmin)-" --exclude_groups callx
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v1 --exclude_regex "(imm|intmin)-" --exclude_groups callx --plugin_options "--debug"
 )
 
 add_test(
   NAME cpu_v2
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v2 --exclude_regex "(imm|intmin)-" --exclude_groups callx
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v2 --exclude_regex "(imm|intmin)-" --exclude_groups callx --plugin_options "--debug"
 )
 
 add_test(
   NAME cpu_v3
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v3 --debug true --list_instructions true --exclude_regex "(imm|intmin)-" --exclude_groups callx
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v3 --debug true --list_instructions true --exclude_regex "(imm|intmin)-" --exclude_groups callx --plugin_options "--debug"
 )
 
 add_test(
   NAME elf_format
-  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v3 --debug true --list_instructions true --elf true --exclude_regex "(call_local*|imm-|intmin-)" --exclude_groups callx
+  COMMAND sudo ${PROJECT_BINARY_DIR}/bin/bpf_conformance_runner --test_file_directory ${PROJECT_BINARY_DIR}/tests --plugin_path ${PROJECT_BINARY_DIR}/bin/libbpf_plugin --xdp_prolog true --cpu_version v3 --debug true --list_instructions true --elf true --exclude_regex "(call_local*|imm-|intmin-)" --exclude_groups callx --plugin_options "--debug"
 )
 
 add_test(


### PR DESCRIPTION
This pull request includes enhancements to the GitHub Actions workflow to improve diagnostics and test reruns for the build process. The most important changes include adding steps to rerun failed tests with more verbose output and uploading the build folder for diagnosing issues.

Enhancements to diagnostics and test reruns:

* [`.github/workflows/Build.yml`](diffhunk://#diff-33612a4f71286f3a6658f13c4f2f1947085f3686fa78e2090306cce1c0a6ffbcR137-R149): Added a step to rerun failed tests with more verbose output when the platform is `ubuntu-latest` and there is a failure. (`[.github/workflows/Build.ymlR137-R149](diffhunk://#diff-33612a4f71286f3a6658f13c4f2f1947085f3686fa78e2090306cce1c0a6ffbcR137-R149)`)
* [`.github/workflows/Build.yml`](diffhunk://#diff-33612a4f71286f3a6658f13c4f2f1947085f3686fa78e2090306cce1c0a6ffbcR137-R149): Added a step to always upload the build folder as an artifact for diagnosing issues, using the `actions/upload-artifact` action. (`[.github/workflows/Build.ymlR137-R149](diffhunk://#diff-33612a4f71286f3a6658f13c4f2f1947085f3686fa78e2090306cce1c0a6ffbcR137-R149)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced diagnostic capabilities for test failures, including verbose output for rerun tests.
	- Added functionality to upload the build folder as an artifact for easier issue diagnosis.
	- Enhanced BPF conformance tests with debugging options for improved troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->