### PR TITLE
Update to boost 1.86

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -63,7 +63,7 @@ jobs:
           cmake \
           ninja \
           ccache \
-          boost@1.86
+          boost@1.85
 
     - name: Build/install libbpf From Source
       if: ${{ startsWith(inputs.platform, 'ubuntu-') }}

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -63,7 +63,7 @@ jobs:
           cmake \
           ninja \
           ccache \
-          boost
+          boost@1.86
 
     - name: Build/install libbpf From Source
       if: ${{ startsWith(inputs.platform, 'ubuntu-') }}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   find_program(NUGET nuget)
 
   if("${BOOST_VERSION}" STREQUAL "")
-    set(BOOST_VERSION "1.86.0")
+    set(BOOST_VERSION "1.85.0")
   endif()
 
   if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio 17 2022")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   find_program(NUGET nuget)
 
   if("${BOOST_VERSION}" STREQUAL "")
-    set(BOOST_VERSION "1.80.0")
+    set(BOOST_VERSION "1.86.0")
   endif()
 
   if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio 17 2022")


### PR DESCRIPTION
This pull request updates the Boost library version used in the project to 1.86.0 across the build configuration and CMake setup. The changes ensure consistency in dependency management and compatibility with the updated Boost version.

### Build configuration updates:

* [`.github/workflows/Build.yml`](diffhunk://#diff-33612a4f71286f3a6658f13c4f2f1947085f3686fa78e2090306cce1c0a6ffbcL66-R66): Updated the Boost library installation to use `boost@1.86` instead of the default version, ensuring the workflow installs the correct version during CI builds.

### CMake configuration updates:

* [`src/CMakeLists.txt`](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4L14-R14): Changed the default `BOOST_VERSION` from `1.80.0` to `1.86.0` to align with the updated dependency version.