### PR TITLE
Add option to make boost backwards compatible

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   find_program(NUGET nuget)
 
   if("${BOOST_VERSION}" STREQUAL "")
-    set(BOOST_VERSION "1.80.0")
+    set(BOOST_VERSION "1.87.0")
   endif()
 
   if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio 17 2022")

--- a/src/boost_helper.h
+++ b/src/boost_helper.h
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include <boost/version.hpp>
+#if BOOST_VERSION < 108800
+#include <boost/process.hpp>
+#else
+#define BOOST_PROCESS_VERSION 1
+#include <boost/process/v1/args.hpp>
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/exception.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/pipe.hpp>
+#include <boost/process/v1/posix.hpp>
+#endif

--- a/src/bpf_conformance.cc
+++ b/src/bpf_conformance.cc
@@ -3,7 +3,8 @@
 
 #include "../include/bpf_conformance.h"
 
-#include <boost/process.hpp>
+//#include <boost/process.hpp>
+#include "boost_helper.h"
 #include <iostream>
 #include <regex>
 #include <set>


### PR DESCRIPTION
This pull request introduces a small change to the `src/bpf_conformance.cc` file. It adds a macro definition for `BOOST_PROCESS_VERSION` to ensure compatibility with the Boost.Process library.

* [`src/bpf_conformance.cc`](diffhunk://#diff-a629e11824b7ef0e5e934ff2ae700032b2d2ea3dd4a33b029ec2f34082057993R6-R7): Defined `BOOST_PROCESS_VERSION` with a value of `1` to address compatibility requirements with the Boost.Process library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the default Boost library version for MSVC builds to 1.87.0.
- **New Features**
  - Improved compatibility with different Boost versions for process management.
- **Refactor**
  - Streamlined Boost.Process header inclusion to better handle various Boost versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->