### PR TITLE
Force a minimal size of memory for libbpf test programs

### DIFF
--- a/libbpf_plugin/libbpf_plugin.cc
+++ b/libbpf_plugin/libbpf_plugin.cc
@@ -32,6 +32,10 @@ enum bpf_stats_type_fake
 
 #include "../include/bpf_conformance.h"
 
+// This is the minimal size of the memory required to initialize a test program in the kernel,
+// defined in linux/include/uapi/linux/if_ether.h in the kernel source tree.
+#define ETH_HLEN 14
+
 /**
  * @brief Read in a string of hex bytes and return a vector of bytes.
  *
@@ -294,6 +298,10 @@ main(int argc, char** argv)
     auto map = bpf_map_create(BPF_MAP_TYPE_ARRAY, NULL, sizeof(int), sizeof(uint64_t), 1, NULL);
 
     std::vector<uint8_t> memory = base16_decode(memory_string);
+    if (memory.size() < ETH_HLEN) {
+        memory.resize(ETH_HLEN, 0);
+    }
+
     std::string log;
     int fd = -1;
     struct bpf_object* elf_object = nullptr;


### PR DESCRIPTION
Hi, the tests are failing when running `libbpf_plugin` on newer versions of Linux kernel.
The issue is that the initialization of test programs requires a minimal 14 bytes of memory.

The kernel patch that introduced this change can be found [here](https://github.com/torvalds/linux/commit/6b3d638ca897e099fa99bd6d02189d3176f80a47).

lmk if the change makes sense, thanks :).
