### PR TITLE
Cmake now included in container image

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -60,7 +60,6 @@ jobs:
       if: inputs.platform == 'macos-latest'
       run: |
         brew install \
-          cmake \
           ninja \
           ccache \
           boost


### PR DESCRIPTION
Fix build break caused by updated MacOS runner image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated macOS build workflow by removing CMake from the Homebrew prerequisites; Ninja, ccache, and Boost remain installed. No other build steps changed.
  - No impact on application behavior or features; end users will not see any changes.
  - Builds on macOS continue to run as before, with no expected changes to performance or compatibility.
  - No updates to public APIs or exported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->