### PR TITLE
Fix CPU version gating for MEMSX sign-extending loads

### DIFF
--- a/src/opcode_names.h
+++ b/src/opcode_names.h
@@ -301,9 +301,9 @@ static const std::set<bpf_conformance_instruction_t, InstCmp> instructions_from_
     {bpf_conformance_test_cpu_version_t::v3, bpf_conformance_groups_t::base32, 0x7e},
     {bpf_conformance_test_cpu_version_t::v1, bpf_conformance_groups_t::base64, 0x7f},
     // MEMSX sign-extending loads.
-    {bpf_conformance_test_cpu_version_t::v1, bpf_conformance_groups_t::base32, 0x81},
-    {bpf_conformance_test_cpu_version_t::v1, bpf_conformance_groups_t::base32, 0x89},
-    {bpf_conformance_test_cpu_version_t::v1, bpf_conformance_groups_t::base32, 0x91},
+    {bpf_conformance_test_cpu_version_t::v4, bpf_conformance_groups_t::base32, 0x81},
+    {bpf_conformance_test_cpu_version_t::v4, bpf_conformance_groups_t::base32, 0x89},
+    {bpf_conformance_test_cpu_version_t::v4, bpf_conformance_groups_t::base32, 0x91},
     {bpf_conformance_test_cpu_version_t::v1, bpf_conformance_groups_t::base32, 0x84},
     {bpf_conformance_test_cpu_version_t::v1, bpf_conformance_groups_t::base32, 0x85, 0x00},
     {bpf_conformance_test_cpu_version_t::v3, bpf_conformance_groups_t::base32, 0x85, 0x01},


### PR DESCRIPTION
MEMSX sign-extending load opcodes (0x81, 0x89, 0x91) were introduced in Linux 5.12 (eBPF ISA v4). This updates `instructions_from_spec` to gate these opcodes as `bpf_conformance_test_cpu_version_t::v4` instead of `v1`, so CPU-version-based skipping matches the spec history.