### PR TITLE
ci: Add Renovate config for libbpf version tracking

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "_comment": "Copyright (c) Microsoft Corporation. SPDX-License-Identifier: MIT",
+  "extends": [
+    "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["\\.github/scripts/build-libbpf\\.sh$"],
+      "matchStrings": [
+        "--branch (?<currentValue>v[\\d.]+) https://github.com/(?<depName>libbpf/libbpf)\\.git"
+      ],
+      "datasourceTemplate": "github-releases"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["regex"],
+      "matchPackageNames": ["libbpf/libbpf"],
+      "groupName": "libbpf"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #174

## Summary
The libbpf version is hardcoded in `.github/scripts/build-libbpf.sh` and wasn't being tracked by dependabot. This PR adds Renovate configuration with a custom regex manager to automatically create PRs when new libbpf versions are released.

## How it works
- Uses Renovate's `customManagers` with regex to match the version pattern in the build script
- Tracks releases from `libbpf/libbpf` via GitHub releases datasource
- No git submodule required

## Note
Requires enabling the [Renovate GitHub App](https://github.com/apps/renovate) for this repository.