### PR TITLE
fix: Use LIBBPF_OPTS macro for better version compatibility

### DIFF
--- a/libbpf_plugin/libbpf_plugin.cc
+++ b/libbpf_plugin/libbpf_plugin.cc
@@ -130,13 +130,12 @@ load_bpf_instructions(const std::string& program_string, int map_fd, size_t memo
         &log[0],
         log_size);
 #else
-    bpf_prog_load_opts opts{
-        .sz = sizeof(opts),
+    LIBBPF_OPTS(bpf_prog_load_opts, opts,
         .attempts = 1,
         .expected_attach_type = BPF_XDP,
         .log_size = log_size,
         .log_buf = &log[0],
-    };
+    );
     int fd = bpf_prog_load(
         BPF_PROG_TYPE_XDP,
         "conformance_test",
@@ -180,14 +179,14 @@ load_elf_file(const std::string& file_contents, int map_fd, std::string& log)
     int fd = -1;
     int error = 0;
     bool result = false;
-    bpf_object_open_opts opts = {};
-    opts.sz = sizeof(opts);
-    opts.relaxed_maps = true;
+    LIBBPF_OPTS(bpf_object_open_opts, opts,
+        .relaxed_maps = true,
+    );
 
-    libbpf_prog_handler_opts handler_opts = {};
-    handler_opts.sz = sizeof(libbpf_prog_handler_opts);
-    handler_opts.cookie = map_fd;
-    handler_opts.prog_prepare_load_fn = bpf_elf_file_prepare_load_handler;
+    LIBBPF_OPTS(libbpf_prog_handler_opts, handler_opts,
+        .cookie = map_fd,
+        .prog_prepare_load_fn = bpf_elf_file_prepare_load_handler,
+    );
 
     int default_program_handler_handler = 0;
     int xdp_program_handler_handle = 0;
@@ -327,14 +326,13 @@ main(int argc, char** argv)
     }
 
     // Run program.
-    bpf_test_run_opts test_run{
-        .sz = sizeof(bpf_test_run_opts),
+    LIBBPF_OPTS(bpf_test_run_opts, test_run,
         .data_in = memory.data(),
         .data_out = memory.data(),
         .data_size_in = static_cast<uint32_t>(memory.size()),
         .data_size_out = static_cast<uint32_t>(memory.size()),
         .repeat = 1,
-    };
+    );
 
     int result = bpf_prog_test_run_opts(fd, &test_run);
     if (result == 0) {


### PR DESCRIPTION
Fixes #129

## Summary
Use the `LIBBPF_OPTS` macro for all libbpf option structs to ensure proper forward/backward compatibility.

## The Problem
The error `bpf_test_run_opts has non-zero extra bytes` occurs when:
- libbpf (compiled into the plugin) has a newer struct definition
- The kernel is older and doesn't recognize all fields

libbpf detects the size mismatch and rejects the call.

## The Fix
The `LIBBPF_OPTS` macro:
- Zero-initializes the entire struct
- Sets `.sz` to the appropriate value for the compiled libbpf version
- Provides compatibility across kernel/libbpf version differences

## Changes
Updated all libbpf option structs to use `LIBBPF_OPTS`:
- `bpf_prog_load_opts`
- `bpf_object_open_opts`
- `libbpf_prog_handler_opts`
- `bpf_test_run_opts`

## Note
This is a belt-and-suspenders fix. PR #449 (merged) already requires libbpf >= 1.0.0 at configure time, which prevents most version mismatch scenarios.